### PR TITLE
Add missing entry for http.timeouts plugin to docs sidebar

### DIFF
--- a/site/includes/docs-nav-side.html
+++ b/site/includes/docs-nav-side.html
@@ -44,6 +44,7 @@
 		<li><a href="/docs/startup">startup</a></li>
 		<li><a href="/docs/status">status</a></li>
 		<li><a href="/docs/templates">templates</a></li>
+		<li><a href="/docs/timeouts">timeouts</a></li>
 		<li><a href="/docs/tls">tls</a></li>
 		<li><a href="/docs/websocket">websocket</a></li>
 	</ul>


### PR DESCRIPTION
Pretty self-explanatory. It looks like this was the only missing plugin in the sidebar.