### PR TITLE
rewrite docs: update "if" conditions.

### DIFF
--- a/site/docs/rewrite.html
+++ b/site/docs/rewrite.html
@@ -71,9 +71,12 @@
 					<li><code>starts_with</code> = b is a prefix of a</li>
 					<li><code>not_starts_with</code> = b is NOT a prefix of a</li>
 					<li><code>ends_with</code> = b is a suffix of a</li>
+					<li><code>not_ends_with</code> = b is NOT a suffix of a</li>
 					<li><code>match</code> = a matches b, where b is a regular expression</li>
 					<li><code>not_match</code> = a does NOT match b, where b is a regular expression</li>
 				</ul>
+
+				<p>Note: As a general rule, you can negate any condition <code>cond</code> by prefixing it with <code>not_</code>.</p>
 
 				<h3 id="examples">Examples</h3>
 


### PR DESCRIPTION
Updated rewrite docs for "if" conditions after merging https://github.com/mholt/caddy/pull/1696 - added missing `not_ends_with` and a note stating the general rule of negating a condition by prefixing it with `not_`.