### PR TITLE
fix: remove paragraph separators

### DIFF
--- a/src/includes/footer.html
+++ b/src/includes/footer.html
@@ -7,7 +7,7 @@
 			in partnership with <a href="https://www.ardanlabs.com/">Ardan Labs</a>
 		</div>
 		<div class="copyright">
-			&copy; 2015-2019 Light Code Labs. All rights reserved. 
+			&copy; 2015-2019 Light Code Labs. All rights reserved.
 			<br>
 			Caddy&reg; is a registered trademark of Light Code Labs, LLC.
 		</div>

--- a/src/index.html
+++ b/src/index.html
@@ -43,7 +43,7 @@
 							Caddy simplifies your infrastructure. It takes care of TLS certificate renewals, OCSP stapling, static file serving, reverse proxying, Kubernetes ingress, and more.
 						</p>
 						<p>
-							 Its modular architecture means you can do more with a single, static binary that compiles for any platform.
+							Its modular architecture means you can do more with a single, static binary that compiles for any platform.
 						</p>
 						<p>
 							Caddy runs great in containers because it has no dependencies&mdash;not even libc. Run Caddy practically anywhere.


### PR DESCRIPTION
There are line and paragraph separators as unicode symbols which are only visible in Chrome on Windows machines and are difficult to detect on other setups. They cause visual inconsistencies and can be safely removed.
https://www.fileformat.info/info/unicode/char/2029/index.htm
https://stackoverflow.com/questions/39603446/why-is-this-symbol-showing-up-on-chrome-and-not-firefox-or-edge