### PR TITLE
fix the anchor fragment in the index of Caddyfile matchers

### DIFF
--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -31,15 +31,15 @@ Full matcher documentation can be found [in each respective matcher module's doc
 
 - [file](#file)
 - [header](#header)
-- [header_regexp](#header_regexp)
+- [header_regexp](#header-regexp)
 - [host](#host)
 - [method](#method)
 - [not](#not)
 - [path](#path)
-- [path_regexp](#path_regexp)
+- [path_regexp](#path-regexp)
 - [protocol](#protocol)
 - [query](#query)
-- [remote_ip](#remote_ip)
+- [remote_ip](#remote-ip)
 
 
 ### file


### PR DESCRIPTION
In the words of @francislavoie, the issue this PR solves is:

> TLDR `<h3 id="header-regexp">header_regexp</h3>`, and the links are `<a href="#header_regexp"></a>`