### PR TITLE
Update config import paths for module example

### DIFF
--- a/src/docs/markdown/extending-caddy.md
+++ b/src/docs/markdown/extending-caddy.md
@@ -293,8 +293,8 @@ import (
 	"os"
 
 	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/config/caddyfile"
-	"github.com/caddyserver/caddy/v2/config/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 )
 


### PR DESCRIPTION
Looks like the import path is wrong. Sanity checking against an [in-tree module](https://github.com/caddyserver/caddy/blob/v2/modules/filestorage/filestorage.go#L19) seems to confirm this change corrects the import path.