### PR TITLE
Correct typo: stderr to stdout

### DIFF
--- a/src/docs/markdown/caddyfile/directives/log.md
+++ b/src/docs/markdown/caddyfile/directives/log.md
@@ -37,7 +37,7 @@ output stderr
 Standard output (console).
 
 ```
-output stderr
+output stdout
 ```
 
 #### discard


### PR DESCRIPTION
This PR corrects mistake in log directive documentation. It should state `stdout` but it is `stderr`.