### PR TITLE
Clarify the usage of `try_files` in Caddyfile, not supporting matchers

### DIFF
--- a/src/docs/markdown/caddyfile/directives/try_files.md
+++ b/src/docs/markdown/caddyfile/directives/try_files.md
@@ -29,6 +29,8 @@ The `try_files` directive is basically a shortcut for:
 rewrite @try_files {http.matchers.file.relative}
 ```
 
+Since this directive is a shortcut, it does not allow a matcher in its syntax. If you need a more complex matcher, then use the above expanded form as a basis.
+
 
 ## Examples
 

--- a/src/docs/markdown/caddyfile/directives/try_files.md
+++ b/src/docs/markdown/caddyfile/directives/try_files.md
@@ -29,7 +29,7 @@ The `try_files` directive is basically a shortcut for:
 rewrite @try_files {http.matchers.file.relative}
 ```
 
-Since this directive is a shortcut, it does not allow a matcher in its syntax. If you need a more complex matcher, then use the above expanded form as a basis.
+Note that this directive does not accept a matcher token. If you need more complex matching logic, then use the expanded form above as a basis.
 
 
 ## Examples


### PR DESCRIPTION
There's precedence for an explanation like this considering [`php_fastcgi`](https://caddyserver.com/docs/caddyfile/directives/php_fastcgi#expanded-form) has a similar explanation as to when the expanded form is still useful