### PR TITLE
docs: Add unix socket example to `php_fastcgi`

### DIFF
--- a/src/docs/markdown/caddyfile/directives/php_fastcgi.md
+++ b/src/docs/markdown/caddyfile/directives/php_fastcgi.md
@@ -67,3 +67,9 @@ Same, but only for requests under `/blog/`:
 ```
 php_fastcgi /blog/* 127.0.0.1:9000
 ```
+
+When using php-fpm listening via a unix socket:
+
+```
+php_fastcgi unix//run/php/php7.4-fpm.sock
+```


### PR DESCRIPTION
As suggested in https://caddy.community/t/v2-setting-up-php/7518