### PR TITLE
docs: Upgrade guide root `*` matcher token, because path starts with `/`

### DIFF
--- a/src/docs/markdown/quick-starts/static-files.md
+++ b/src/docs/markdown/quick-starts/static-files.md
@@ -70,7 +70,7 @@ You can also use another folder as the site root:
 ```
 localhost
 
-root /home/me/mysite
+root * /home/me/mysite
 file_server
 ```
 


### PR DESCRIPTION
The syntax has changed with Caddy v2:
* https://caddyserver.com/docs/v2-upgrade#root