### PR TITLE
Straight rotated aside elements out on hover

### DIFF
--- a/src/resources/css/v2-landing.css
+++ b/src/resources/css/v2-landing.css
@@ -316,6 +316,13 @@ asciinema-player {
 	box-shadow: 10px 10px 25px rgba(0, 0, 0, 0.1);
 }
 
+.display > * {
+	transition: transform 0.5s;
+}
+.display:hover > * {
+	transform: none;
+}
+
 .display.right > * {
 	transform: rotateY(-25deg);
 }


### PR DESCRIPTION
I love the rotate effect on aside elements, but it compromises readability, especially on video elements. Here we straight them out on hover with a good looking ease effect.