### PR TITLE
docs: add instructions for Homebrew

### DIFF
--- a/src/docs/markdown/download.md
+++ b/src/docs/markdown/download.md
@@ -58,3 +58,7 @@ RHEL/CentOS 7:
 ## DigitalOcean
 
 [**Deploy a Caddy droplet on DigitalOcean**](https://marketplace.digitalocean.com/apps/caddy)
+
+## macOS
+
+<pre><code class="cmd bash">brew install caddy</code></pre>


### PR DESCRIPTION
Figured if Caddy is available in Homebrew might as well add it to the Downloads page.