### PR TITLE
docs: Add 404 handling

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -15,3 +15,16 @@ rewrite /docs/modules/* /docs/modules/index.html
 rewrite /docs/*         /docs/index.html
 
 reverse_proxy /api/* localhost:4444
+
+handle_errors {
+	@error {
+		expression {http.error.status_code} in [404, 500]
+	}
+	handle @error {
+		rewrite 404.html
+		root * src
+		encode gzip
+		templates
+		file_server
+	}
+}

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>404 &mdash; Caddy Documentation</title>
+		{{include "/includes/docs-head.html"}}
+		<meta property="og:title" content="404 - Caddy Documentation">
+		<meta name="twitter:title" value="404 - Caddy Documentation">
+	</head>
+	<body>
+		{{include "/includes/docs-header.html"}}
+		<main>
+			{{include "/includes/docs-nav.html"}}
+			<div class="article-container">
+				<div class="paper" id="paper1"></div>
+				<div class="paper" id="paper2"></div>
+				<article class="paper paper3">
+					{{markdown "# 404\n\n<center>Sorry! The page you requested wasn't found.</center>"}}
+				</article>
+			</div>
+			<div class="sidebar"></div>
+		</main>
+		{{include "/includes/footer.html"}}
+	</body>
+</html>


### PR DESCRIPTION
Closes #35 

Adds a 404 page if a 404 or 500 is encountered.

It just renders with the docs template right now, easiest solution right now.

![image](https://user-images.githubusercontent.com/2111701/82160354-b939a080-9862-11ea-8578-38964bb18483.png)
