### PR TITLE
docs: Add `clients` subdirective to `tls` directive docs

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -141,6 +141,14 @@ directive "\"abc def\""
 
 Inside quoted tokens, all other characters are treated literally, including spaces, tabs, and newlines.
 
+You can also use a backtick (`\``) to quote tokens:
+
+```
+directive `"foo bar"`
+```
+
+Backtick strings are convenient when tokens contain quote literals.
+
 
 
 ## Addresses
@@ -219,11 +227,16 @@ You can use any [Caddy placeholders](/docs/conventions#placeholders) in the Cadd
 |-----------------|---------------------------------|
 | `{dir}`         | `{http.request.uri.path.dir}`   |
 | `{file}`        | `{http.request.uri.path.file}`  |
+| `{header.*}`    | `{http.request.header.*}`       |
 | `{host}`        | `{http.request.host}`           |
+| `{labels.*}`    | `{http.request.host.labels.*}`  |
 | `{hostport}`    | `{http.request.hostport}`       |
 | `{method}`      | `{http.request.method}`         |
 | `{path}`        | `{http.request.uri.path}`       |
+| `{path.*}`      | `{http.request.uri.path.*}`     |
 | `{query}`       | `{http.request.uri.query}`      |
+| `{query.*}`     | `{http.request.uri.query.*}`    |
+| `{re.*.*}`      | `{http.regexp.*.*}`             |
 | `{remote}`      | `{http.request.remote}`         |
 | `{remote_host}` | `{http.request.remote.host}`    |
 | `{remote_port}` | `{http.request.remote.port}`    |
@@ -235,6 +248,7 @@ You can use any [Caddy placeholders](/docs/conventions#placeholders) in the Cadd
 | `{tls_client_issuer}`      | `{http.request.tls.client.issuer}`      |
 | `{tls_client_serial}`      | `{http.request.tls.client.serial}`      |
 | `{tls_client_subject}`     | `{http.request.tls.client.subject}`     |
+
 
 
 ## Snippets

--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -141,13 +141,13 @@ directive "\"abc def\""
 
 Inside quoted tokens, all other characters are treated literally, including spaces, tabs, and newlines.
 
-You can also use a backtick (`\``) to quote tokens:
+You can also use a backtick <code>`</code> to quote tokens:
 
-```
+```caddy-d
 directive `"foo bar"`
 ```
 
-Backtick strings are convenient when tokens contain quote literals.
+Backtick strings are convenient when tokens contain quote literals, e.g. JSON text.
 
 
 
@@ -231,6 +231,7 @@ You can use any [Caddy placeholders](/docs/conventions#placeholders) in the Cadd
 | `{host}`        | `{http.request.host}`           |
 | `{labels.*}`    | `{http.request.host.labels.*}`  |
 | `{hostport}`    | `{http.request.hostport}`       |
+| `{port}`        | `{http.request.port}`           |
 | `{method}`      | `{http.request.method}`         |
 | `{path}`        | `{http.request.uri.path}`       |
 | `{path.*}`      | `{http.request.uri.path.*}`     |

--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -142,7 +142,7 @@ transport http {
 - **tls_insecure_skip_verify** turns off security. _Do not use in production._
 - **tls_timeout** is a [duration value](/docs/conventions#durations) that specifies how long to wait for the TLS handshake to complete.
 - **tls_trusted_ca_certs** is a list of PEM files that specify CA public keys to trust when connecting to the backend.
-- **tls_server_name** sets the ServerName (SNI) to put in the ClientHello; only needed if the remote server it.
+- **tls_server_name** sets the ServerName (SNI) to put in the ClientHello; only needed if the remote server requires it.
 - **keepalive** is either `off` or a [duration value](/docs/conventions#durations) that specifies how long to keep connections open.
 - **keepalive_idle_conns** defines the maximum number of connections to keep alive.
 

--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -62,7 +62,7 @@ Upstream addresses can take the form of a conventional [Caddy network address](/
 - `unix//var/php.sock`
 - `srv+http://internal:5099`
 
-Note: Schemes cannot be mixed, since they modify the common transport configuration (a TLS-enabled transport cannot carry both HTTPS and plaintext HTTP). Specifying ports 80 and 443 are the same as specifying the HTTP and HTTPS schemes, respectively. Any explicit transport configuration will not be overwritten, and omitting schemes or using other ports will not assume a particular transport. Additionally, schemes cannot contain paths or query strings, as that would imply simultaneous rewriting the request while proxying, which behavior is not defined or supported.
+Note: Schemes cannot be mixed, since they modify the common transport configuration (a TLS-enabled transport cannot carry both HTTPS and plaintext HTTP). Specifying ports 80 and 443 are the same as specifying the HTTP and HTTPS schemes, respectively. Any explicit transport configuration will not be overwritten, and omitting schemes or using other ports will not assume a particular transport. Additionally, schemes cannot contain paths or query strings, as that would imply simultaneous rewriting the request while proxying, which behavior is not defined or supported. If the address is not a URL (i.e. does not have a scheme), then placeholders can be used, but this makes the upstream dynamic.
 
 **Load balancing** is used whenever more than one upstream is defined.
 
@@ -128,6 +128,7 @@ transport http {
 	tls_insecure_skip_verify
 	tls_timeout <duration>
 	tls_trusted_ca_certs <pem_files...>
+    tls_server_name <sni>
 	keepalive [off|<duration>]
 	keepalive_idle_conns <max_count>
 }
@@ -141,6 +142,7 @@ transport http {
 - **tls_insecure_skip_verify** turns off security. _Do not use in production._
 - **tls_timeout** is a [duration value](/docs/conventions#durations) that specifies how long to wait for the TLS handshake to complete.
 - **tls_trusted_ca_certs** is a list of PEM files that specify CA public keys to trust when connecting to the backend.
+- **tls_server_name** sets the ServerName (SNI) to put in the ClientHello; only needed if the remote server it.
 - **keepalive** is either `off` or a [duration value](/docs/conventions#durations) that specifies how long to keep connections open.
 - **keepalive_idle_conns** defines the maximum number of connections to keep alive.
 

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -24,6 +24,13 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 	ca_root   <pem_file>
 	dns       <provider_name> [<params...>]
 	on_demand
+	clients {
+    mode [request|require|verify_if_given|require_and_verify]
+		trusted_ca_certs        <trusted_ca_certs...>
+		trusted_ca_certs_file   <filename...>
+		trusted_leaf_certs      <trusted_leaf_certs...>
+		trusted_leaf_certs_file <filename...>
+  }
 }
 ```
 
@@ -62,7 +69,33 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 - **ca_root** specifies a PEM file that contains a trusted root certificate for the ACME CA endpoint, if not in the system trust store.
 - **dns** enables the [DNS challenge](/docs/automatic-https#dns-challenge) using the specified provider plugin, which must be plugged in from one of the [caddy-dns](https://github.com/caddy-dns) repositories. Each provider plugin may have their own syntax following their name; refer to their docs for details. Maintaining support for each DNS provider is a community effort. [Learn how to enable the DNS challenge for your provider at our wiki.](https://caddy.community/t/how-to-use-dns-provider-modules-in-caddy-2/8148)
 - **on_demand** enables [on-demand TLS](/docs/automatic-https#on-demand-tls) for the hostnames given in the site block's address(es).
+- **clients** enables and configures TLS client authentication.
 
+The `clients` block can look like this:
+
+```caddy-d
+clients {
+	mode                    [request|require|verify_if_given|require_and_verify]
+	trusted_ca_certs        <trusted_ca_certs...>
+	trusted_ca_certs_file   <filename...>
+	trusted_leaf_certs      <trusted_leaf_certs...>
+	trusted_leaf_certs_file <filename...>
+}
+```
+
+- **trusted_ca_certs** is a list of base64 DER-encoded CA certificates against which to validate client certificates. Client certs which are not signed by any of these CAs will be rejected.
+- **trusted_ca_certs_file** is a list of base64 DER-encoded CA certificate files against which to validate client certificates. Client certs which are not signed by any of these CAs will be rejected.
+- **trusted_leaf_certs** is a list of base64 DER-encoded client leaf certs to accept. If this list is not empty, client certs which are not in this list will be rejected
+- **trusted_leaf_certs_file** is a list of base64 DER-encoded CA certificate files against which to validate client certificates. Client certs which are not signed by any of these CAs will be rejected.
+- **mode** is the mode for authenticating the client. Allowed values are:
+  | Mode               | Description                                                                              |
+  |--------------------|------------------------------------------------------------------------------------------|
+  | request            | Ask clients for a certificate, but allow even if there isn't one; do not verify it       |
+  | require            | Require clients to present a certificate, but do not verify it                           |
+  | verify_if_given    | Ask clients for a certificate; allow even if there isn't one, but verify it if there is  |
+	| require_and_verify | Require clients to present a valid certificate that is verified                          |
+
+	The default mode is `require_and_verify` if any TrustedCACerts or TrustedLeafCerts are provided; otherwise, the default mode is `require`
 
 
 ## Examples
@@ -98,5 +131,16 @@ Enable the DNS challenge for a domain managed on Cloudflare with account credent
 ```caddy-d
 tls {
 	dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+}
+```
+
+Enable TLS Client Authentication
+
+```caddy-d
+tls {
+  clients {
+    mode                    require_and_verify
+    trusted_ca_certs_file   cacerts.crt
+  }
 }
 ```

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -138,9 +138,9 @@ Enable TLS Client Authentication
 
 ```caddy-d
 tls {
-  clients {
-    mode                    require_and_verify
-    trusted_ca_certs_file   cacerts.crt
-  }
+	clients {
+		mode                    require_and_verify
+		trusted_ca_certs_file   cacerts.crt
+	}
 }
 ```

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -93,7 +93,7 @@ clients {
   | request            | Ask clients for a certificate, but allow even if there isn't one; do not verify it       |
   | require            | Require clients to present a certificate, but do not verify it                           |
   | verify_if_given    | Ask clients for a certificate; allow even if there isn't one, but verify it if there is  |
-	| require_and_verify | Require clients to present a valid certificate that is verified                          |
+  | require_and_verify | Require clients to present a valid certificate that is verified                          |
 
 	The default mode is `require_and_verify` if any TrustedCACerts or TrustedLeafCerts are provided; otherwise, the default mode is `require`
 

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -25,12 +25,12 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 	dns       <provider_name> [<params...>]
 	on_demand
 	clients {
-    mode [request|require|verify_if_given|require_and_verify]
+		mode [request|require|verify_if_given|require_and_verify]
 		trusted_ca_certs        <trusted_ca_certs...>
 		trusted_ca_certs_file   <filename...>
 		trusted_leaf_certs      <trusted_leaf_certs...>
 		trusted_leaf_certs_file <filename...>
-  }
+	}
 }
 ```
 

--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -98,7 +98,7 @@ Defining a matcher with a unique name gives you more flexibility, allowing you t
 
 or, if there is only one matcher in the set:
 
-```
+```caddy-d
 @name ...
 ```
 
@@ -118,7 +118,7 @@ This proxies only the requests that have a header field named "Connection" conta
 
 If the matcher set consists of only one matcher, a one-liner syntax also works:
 
-```
+```caddy-d
 @post method POST
 reverse_proxy @post localhost:6001
 ```
@@ -197,7 +197,7 @@ By files.
 
 Because `try_files` with a policy of `first_exist` is so common, there is a one-line shortcut for that:
 
-```
+```caddy-d
 file <files...>
 ```
 

--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -50,10 +50,11 @@ reverse_proxy /api/* localhost:9000
 To match on anything other than a path, define a [named matcher](#named-matchers) and refer to it using `@name`:
 
 ```caddy-d
-@post {
+@postfoo {
 	method POST
+	path /foo/*
 }
-reverse_proxy @post localhost:9000
+reverse_proxy @postfoo localhost:9000
 ```
 
 
@@ -61,7 +62,7 @@ reverse_proxy @post localhost:9000
 
 ### Wildcard matchers
 
-The wildcard matcher `*` matches all requests, and is only needed if a matcher token is required. For example, if the first argument you want to give a directive also happens to be a path, it would look exactly like a path matcher! So you can use a wildcard matcher to disambiguate, for example:
+The wildcard (or "catch-all") matcher `*` matches all requests, and is only needed if a matcher token is required. For example, if the first argument you want to give a directive also happens to be a path, it would look exactly like a path matcher! So you can use a wildcard matcher to disambiguate, for example:
 
 ```caddy-d
 root * /home/www/mysite
@@ -85,12 +86,20 @@ Path matcher tokens must start with a forward slash `/`.
 
 ### Named matchers
 
+All matchers that are not comprised of a single path matcher or a wildcard matcher must be named matchers. This is a matcher that is defined outside of any particular directive, and can be reused.
+
 Defining a matcher with a unique name gives you more flexibility, allowing you to combine [any available matchers](#standard-matchers) into a set:
 
 ```caddy-d
 @name {
 	...
 }
+```
+
+or, if there is only one matcher in the set:
+
+```
+@name ...
 ```
 
 Then you can use the matcher like so: `@name`
@@ -106,6 +115,15 @@ reverse_proxy @websockets localhost:6001
 ```
 
 This proxies only the requests that have a header field named "Connection" containing the word "Upgrade", and another field named "Upgrade" with a value of "websocket".
+
+If the matcher set consists of only one matcher, a one-liner syntax also works:
+
+```
+@post method POST
+reverse_proxy @post localhost:6001
+```
+
+(One-liner named matchers cannot open a block.)
 
 Like directives, named matcher definitions must go inside the site blocks that use them.
 
@@ -177,8 +195,13 @@ By files.
 	- `most_recent_modified` chooses the file that was most recently modified.
 - `split_path` will cause the path to be split at the first delimiter in the list that is found in each filepath to try. For each split value, the left-hand side of the split including the delimiter itself will be the filepath that is tried. For example, `/remote.php/dav/` using a delimiter of `.php` would try the file `/remote.php`. Each delimiter must appear at the end of a URI path component in order to be used as a split delimiter. This is a niche setting and is mostly used when serving PHP sites.
 
-An empty `file` matcher will see if the requested file (verbatim from the URI, relative to the [site root](/docs/caddyfile/directives/root)) exists.
+Because `try_files` with a policy of `first_exist` is so common, there is a one-line shortcut for that:
 
+```
+file <files...>
+```
+
+An empty `file` matcher (one with no files listed after it) will see if the requested file&mdash;verbatim from the URI, relative to the [site root](/docs/caddyfile/directives/root)&mdash;exists.
 
 ### header
 

--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -172,13 +172,13 @@ Formats or prettifies a Caddyfile, then exits. The result is printed to stdout u
 ### `caddy hash-password`
 
 <pre><code class="cmd bash">caddy hash-password
-	--plaintext &lt;password&gt;
+	[--plaintext &lt;password&gt;]
 	[--algorithm &lt;name&gt;]
 	[--salt &lt;string&gt;]</code></pre>
 
 Hashes a password and writes the output to stdout in base64 encoding, then exits.
 
-`--plaintext` is the plaintext form of the password.
+`--plaintext` is the plaintext form of the password. If omitted, interactive mode will be assumed and the user will be shown a prompt to enter the password manually.
 
 `--algorithm` may be bcrypt or scrypt. Default is bcrypt.
 

--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -250,6 +250,7 @@ This command disables the admin API so it is easier to run multiple instances on
 <pre><code class="cmd bash">caddy run
 	[--config &lt;path&gt;]
 	[--adapter &lt;name&gt;]
+	[--pidfile &lt;file&gt;]
 	[--environ]
 	[--resume]
 	[--watch]</code></pre>
@@ -259,6 +260,8 @@ Runs Caddy and blocks indefinitely; i.e. "daemon" mode.
 `--config` specifies an initial config file to immediately load and use. If no config is specified, Caddy will run with a blank configuration and use default settings for the [admin API endpoints](/docs/api), which can be used to feed it new configuration. As a special case, if the current working directory has a file called "Caddyfile" and the `caddyfile` config adapter is plugged in (default), then that file will be loaded and used to configure Caddy, even without any command line flags.
 
 `--adapter` is the name of the config adapter to use when loading the initial config, if any. This flag is not necessary if the `--config` filename starts with "Caddyfile" which assumes the `caddyfile` adapter. Otherwise, this flag is required if the provided config file is not in Caddy's native JSON format. Any warnings will be printed to the log, but beware that any adaptation without errors will immediately be used, even if there are warnings. If you want to review the results of the adaptation first, use the [`caddy adapt`](#caddy-adapt) subcommand.
+
+`--pidfile` writes the PID to the specified file.
 
 `--environ` prints out the environment before starting. This is the same as the `caddy environ` command, but does not exit after printing.
 
@@ -277,6 +280,7 @@ Runs Caddy and blocks indefinitely; i.e. "daemon" mode.
 <pre><code class="cmd bash">caddy start
 	[--config &lt;path&gt;]
 	[--adapter &lt;name&gt;]
+	[--pidfile &lt;file&gt;]
 	[--watch]</code></code></pre>
 
 Same as [`caddy run`](#caddy-run), but in the background. This command only blocks until the background process is running successfully (or fails to run), then returns.

--- a/src/docs/markdown/conventions.md
+++ b/src/docs/markdown/conventions.md
@@ -140,7 +140,7 @@ It is crucial that this directory is persistent and writeable by Caddy.
 
 ## Durations
 
-Duration strings are commonly used throughout Caddy's configuration. They take on the same format as [Go's time.ParseDuration syntax](https://golang.org/pkg/time/#ParseDuration). Valid units are:
+Duration strings are commonly used throughout Caddy's configuration. They take on the same format as [Go's time.ParseDuration syntax](https://golang.org/pkg/time/#ParseDuration) except you can also use `d` for day (we assume 1 day = 24 hours for simplicity). Valid units are:
 
 - `ns` (nanosecond)
 - `us`/`µs` (microsecond)
@@ -148,6 +148,7 @@ Duration strings are commonly used throughout Caddy's configuration. They take o
 - `s` (second)
 - `m` (minute)
 - `h` (hour)
+- `d` (day)
 
 Examples:
 
@@ -155,5 +156,6 @@ Examples:
 - `5s`
 - `1.5h`
 - `2h45m`
+- `90d`
 
 In the [JSON config](/docs/json/), duration values can also be integers which represent nanoseconds.


### PR DESCRIPTION
This PR update the documentation for the Caddyfile `tls` directive for `v2.1`.

This basically adds the `clients` sub-directive which is being added in `v2.1` via [this PR](https://github.com/caddyserver/caddy/pull/3335)

The `clients` subdirective enables TLS Client Authentication using the Caddyfile.