### PR TITLE
Add the tls.client_auth Caddyfile directive doc

### DIFF
--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -88,6 +88,9 @@ client_auth {
 - **trusted_ca_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
 - **trusted_leaf_cert** is a base64 DER-encoded client leaf certificate to accept. Client certificates which are not signed by any of these CAs will be rejected.
 - **trusted_leaf_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
+
+	Multiple `trusted_*` directives may be specified as a way to chain multiple CA or leaf certificates.
+
 - **mode** is the mode for authenticating the client. Allowed values are:
   | Mode               | Description                                                                              |
   |--------------------|------------------------------------------------------------------------------------------|
@@ -134,13 +137,14 @@ tls {
 }
 ```
 
-Enable TLS Client Authentication and require clients to present a valid certificate that is verified against the provided `trusted_ca_cert_file`
+Enable TLS Client Authentication and require clients to present a valid certificate that is verified against all the provided CA's via `trusted_ca_cert_file`
 
 ```caddy-d
 tls {
 	client_auth {
 		mode                 require_and_verify
 		trusted_ca_cert_file ../caddy.ca.cer
+		trusted_ca_cert_file ../root.ca.cer
 	}
 }
 ```

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -69,37 +69,26 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 - **ca_root** specifies a PEM file that contains a trusted root certificate for the ACME CA endpoint, if not in the system trust store.
 - **dns** enables the [DNS challenge](/docs/automatic-https#dns-challenge) using the specified provider plugin, which must be plugged in from one of the [caddy-dns](https://github.com/caddy-dns) repositories. Each provider plugin may have their own syntax following their name; refer to their docs for details. Maintaining support for each DNS provider is a community effort. [Learn how to enable the DNS challenge for your provider at our wiki.](https://caddy.community/t/how-to-use-dns-provider-modules-in-caddy-2/8148)
 - **on_demand** enables [on-demand TLS](/docs/automatic-https#on-demand-tls) for the hostnames given in the site block's address(es).
-- **client_auth** enables and configures TLS client authentication.
+- **client_auth** enables and configures TLS client authentication:
+	- **mode** is the mode for authenticating the client. Allowed values are:
 
+		| Mode               | Description                                                                              |
+		|--------------------|------------------------------------------------------------------------------------------|
+		| request            | Ask clients for a certificate, but allow even if there isn't one; do not verify it       |
+		| require            | Require clients to present a certificate, but do not verify it                           |
+		| verify_if_given    | Ask clients for a certificate; allow even if there isn't one, but verify it if there is  |
+		| require_and_verify | Require clients to present a valid certificate that is verified                          |
 
-The `client_auth` block can look like this:
-
-```caddy-d
-client_auth {
-	mode                   [request|require|verify_if_given|require_and_verify]
-	trusted_ca_cert        <base64_der>
-	trusted_ca_cert_file   <filename>
-	trusted_leaf_cert      <base64_der>
-	trusted_leaf_cert_file <filename>
-}
-```
-
-- **trusted_ca_cert** is a base64 DER-encoded CA certificate against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
-- **trusted_ca_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
-- **trusted_leaf_cert** is a base64 DER-encoded client leaf certificate to accept. Client certificates which are not signed by any of these CAs will be rejected.
-- **trusted_leaf_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
+	Default: `require_and_verify` if any `trusted_ca_cert` or `trusted_leaf_cert` are provided; otherwise, `require`.
+	
+	- **trusted_ca_cert** is a base64 DER-encoded CA certificate against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
+	- **trusted_ca_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
+	- **trusted_leaf_cert** is a base64 DER-encoded client leaf certificate to accept. Client certificates which are not signed by any of these CAs will be rejected.
+	- **trusted_leaf_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
 
 	Multiple `trusted_*` directives may be specified as a way to chain multiple CA or leaf certificates.
 
-- **mode** is the mode for authenticating the client. Allowed values are:
-  | Mode               | Description                                                                              |
-  |--------------------|------------------------------------------------------------------------------------------|
-  | request            | Ask clients for a certificate, but allow even if there isn't one; do not verify it       |
-  | require            | Require clients to present a certificate, but do not verify it                           |
-  | verify_if_given    | Ask clients for a certificate; allow even if there isn't one, but verify it if there is  |
-  | require_and_verify | Require clients to present a valid certificate that is verified                          |
 
-	The default mode is `require_and_verify` if any `trusted_ca_cert` or `trusted_leaf_cert` are provided; otherwise, the default mode is `require`
 
 ## Examples
 

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -24,6 +24,13 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 	ca_root   <pem_file>
 	dns       <provider_name> [<params...>]
 	on_demand
+	client_auth {
+		mode                   [request|require|verify_if_given|require_and_verify]
+		trusted_ca_cert        <base64_der>
+		trusted_ca_cert_file   <filename>
+		trusted_leaf_cert      <base64_der>
+		trusted_leaf_cert_file <filename>
+	}
 }
 ```
 
@@ -62,8 +69,34 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 - **ca_root** specifies a PEM file that contains a trusted root certificate for the ACME CA endpoint, if not in the system trust store.
 - **dns** enables the [DNS challenge](/docs/automatic-https#dns-challenge) using the specified provider plugin, which must be plugged in from one of the [caddy-dns](https://github.com/caddy-dns) repositories. Each provider plugin may have their own syntax following their name; refer to their docs for details. Maintaining support for each DNS provider is a community effort. [Learn how to enable the DNS challenge for your provider at our wiki.](https://caddy.community/t/how-to-use-dns-provider-modules-in-caddy-2/8148)
 - **on_demand** enables [on-demand TLS](/docs/automatic-https#on-demand-tls) for the hostnames given in the site block's address(es).
+- **client_auth** enables and configures TLS client authentication.
 
 
+The `client_auth` block can look like this:
+
+```caddy-d
+client_auth {
+	mode                   [request|require|verify_if_given|require_and_verify]
+	trusted_ca_cert        <base64_der>
+	trusted_ca_cert_file   <filename>
+	trusted_leaf_cert      <base64_der>
+	trusted_leaf_cert_file <filename>
+}
+```
+
+- **trusted_ca_cert** is a base64 DER-encoded CA certificate against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
+- **trusted_ca_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
+- **trusted_leaf_cert** is a base64 DER-encoded client leaf certificate to accept. Client certificates which are not signed by any of these CAs will be rejected.
+- **trusted_leaf_cert_file** is a base64 DER-encoded CA certificate file against which to validate client certificates. Client certificates which are not signed by any of these CAs will be rejected.
+- **mode** is the mode for authenticating the client. Allowed values are:
+  | Mode               | Description                                                                              |
+  |--------------------|------------------------------------------------------------------------------------------|
+  | request            | Ask clients for a certificate, but allow even if there isn't one; do not verify it       |
+  | require            | Require clients to present a certificate, but do not verify it                           |
+  | verify_if_given    | Ask clients for a certificate; allow even if there isn't one, but verify it if there is  |
+  | require_and_verify | Require clients to present a valid certificate that is verified                          |
+
+	The default mode is `require_and_verify` if any `trusted_ca_cert` or `trusted_leaf_cert` are provided; otherwise, the default mode is `require`
 
 ## Examples
 
@@ -98,5 +131,16 @@ Enable the DNS challenge for a domain managed on Cloudflare with account credent
 ```caddy-d
 tls {
 	dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+}
+```
+
+Enable TLS Client Authentication
+
+```caddy-d
+tls {
+	client_auth {
+		mode                 require_and_verify
+		trusted_ca_cert_file ../caddy.ca.cer
+	}
 }
 ```

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -134,7 +134,7 @@ tls {
 }
 ```
 
-Enable TLS Client Authentication
+Enable TLS Client Authentication and require clients to present a valid certificate that is verified against the provided `trusted_ca_cert_file`
 
 ```caddy-d
 tls {

--- a/src/resources/css/docs.css
+++ b/src/resources/css/docs.css
@@ -275,6 +275,12 @@ article li {
 	line-height: 1.5em;
 }
 
+article li p,
+article li ul,
+article li ol {
+	margin-bottom: .5em;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
Add the new `client_auth` Caddyfile `tls` sub-directive documentation introduced in `v2.1` via https://github.com/caddyserver/caddy/commit/1dfb11486eacc32af1003242023ddc4544823a31

Related to #49 which was closed prematurely.

@mholt one thing I didn't quite follow is why the Caddyfile uses a different approach (and naming) when compared to its json counterpart [here](https://caddyserver.com/docs/json/apps/http/servers/tls_connection_policies/client_authentication)