### PR TITLE
Fix wrong syntax for srv+ prefixed addresses

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -60,7 +60,8 @@ Upstream addresses can take the form of a conventional [Caddy network address](/
 - `https://example.com`
 - `example.com`
 - `unix//var/php.sock`
-- `srv+http://internal:5099`
+- `srv+http://internal.service.consul`
+- `srv+https://internal.service.consul`
 
 Note: Schemes cannot be mixed, since they modify the common transport configuration (a TLS-enabled transport cannot carry both HTTPS and plaintext HTTP). Specifying ports 80 and 443 are the same as specifying the HTTP and HTTPS schemes, respectively. Any explicit transport configuration will not be overwritten, and omitting schemes or using other ports will not assume a particular transport. Additionally, schemes cannot contain paths or query strings, as that would imply simultaneous rewriting the request while proxying, which behavior is not defined or supported. If the address is not a URL (i.e. does not have a scheme), then placeholders can be used, but this makes the upstream dynamic.
 


### PR DESCRIPTION
SRV DNS records provide the host + port via DNS resolution, so specifying a port for upstream addresses with the `srv+` prefix is a non pattern, IMO.

I've also added the `srv+https` example 