### PR TITLE
Fix doc typo

### DIFF
--- a/src/docs/markdown/quick-starts/caddyfile.md
+++ b/src/docs/markdown/quick-starts/caddyfile.md
@@ -55,7 +55,7 @@ localhost:2016 {
 
 You can give Caddy the updated configuration two ways, either with the API directly:
 
-<pre><code class="cmd bash">curl localhost:2019/load \
+<pre><code class="cmd bash">curl localhost:2016/load \
 	-X POST \
 	-H "Content-Type: text/caddyfile" \
 	--data-binary @Caddyfile


### PR DESCRIPTION
This PR fixes a typo in the docs. The rest of this tutorial uses port `2016`. It looks like the `2019` port that was here is a typo.