### PR TITLE
docs: Better clarify the `auto_https` options and Caddyfile config

### DIFF
--- a/src/docs/markdown/automatic-https.md
+++ b/src/docs/markdown/automatic-https.md
@@ -23,7 +23,7 @@ Here's a 28-second video showing how it works:
 - Caddy serves IP addresses and local/internal hostnames over HTTPS with locally-trusted certificates. Examples: `localhost`, `127.0.0.1`.
 - Caddy serves public DNS names over HTTPS with certificates from [Let's Encrypt](https://letsencrypt.org). Examples: `example.com`, `sub.example.com`, `*.example.com`.
 
-Caddy keeps all certificates renewed, and redirects HTTP (default port 80) to HTTPS (default port 443) automatically (provided [Activation](/docs/automatic-https#activation) is successful).
+Caddy keeps all certificates renewed, and redirects HTTP (default port 80) to HTTPS (default port 443) automatically, provided that [activation](/docs/automatic-https#activation) is successful.
 
 **For local HTTPS:**
 
@@ -76,7 +76,7 @@ Automatic HTTPS never overrides explicit configuration.
 
 You can [customize or disable automatic HTTPS](/docs/json/apps/http/servers/automatic_https/) if necessary.
 
-<aside class="tip">Disabling redirects keeps the HTTPS port enabled as the default port implicitly assigned to an address. The HTTP port was only binded for redirects, to support connecting to both ports, you must [explicitly listen on both for an address](/docs/automatic-https#examples).</aside>
+<aside class="tip">Disabling redirects keeps the HTTPS port enabled as the default port implicitly assigned to an address. The HTTP port is only bound for redirects and for the ACME HTTP challenge. If you need to serve over HTTP, you must explicitly configure Caddy to do it. [See the examples](/docs/automatic-https#examples).</aside>
 
 
 ## Hostname requirements
@@ -227,11 +227,11 @@ To get a wildcard from Let's Encrypt, you simply need to enable the [DNS challen
 
 ## Examples
 
-Caddy implicitly uses the HTTPS port (default 443) for your [server addresses](/docs/conventions#network-addresses) that don't assign an explicit port (which would disable automatic HTTPS). 
+Caddy implicitly uses the HTTPS port (default 443) for your [server addresses](/docs/conventions#network-addresses) that don't specify a port explicitly (which would disable automatic HTTPS). 
 
-The global setting `auto_https` has two values:
-- `disable_redirects` adds an implicit HTTP port redirect.
-- `off` disables automatic HTTPS, default implicit port changes to HTTP for all server addresses.
+Automatic HTTPS can be configured via the Caddyfile with the [`auto_https` global option](/docs/caddyfile/options), or via [per-server JSON configuration](/docs/json/apps/http/servers/automatic_https/). The Caddyfile option can be set to either of the following:
+- `disable_redirects` which disables the implicit HTTP->HTTPS redirect.
+- `off` which disables automatic HTTPS altogether, including the HTTP->HTTPS redirect and automatic enabling of TLS for sites that meet the requirements.
 
 | auto_https        | HTTP        | HTTPS       |
 |-------------------|-------------|-------------|
@@ -245,27 +245,27 @@ The global setting `auto_https` has two values:
 
 ### Disabling automatic HTTPS
 
-For local development environments, you can prevent serving via HTTPS by providing an explicit port assignment(disable per server address) or using the global `auto_https off` setting which will change Caddy's implicit port to be the HTTP port (default 80) globally.
+For local development environments, you can prevent serving via HTTPS by either specifying `http://` or providing a non-HTTPS port to disable per site, or by adding `auto_https off` to the Caddyfile global options which will change Caddy's implicit port to be the HTTP port (default 80).
 
 ```caddy
 {
-  auto_https off
+	auto_https off
 }
 
 # Have caddy implicitly use the HTTP port
 localhost {
-  root * /usr/share/caddy
+	root * /usr/share/caddy
 
-  file_server
+	file_server
 }
 ```
 
 ```caddy
 # Alternatively, provide an explicit port
 localhost:9000 {
-  root * /usr/share/caddy
+	root * /usr/share/caddy
 
-  file_server
+	file_server
 }
 ```
 
@@ -278,27 +278,27 @@ To do so, you can [map several addresses to a site block as a list](/docs/caddyf
 
 ```caddy
 {
-  auto_https disable_redirects
+	auto_https disable_redirects
 }
 
 # Uses the HTTP and HTTPS by protocol
 # These are configurable as global settings
 http://localhost, https://localhost {
-  root * /usr/share/caddy
+	root * /usr/share/caddy
 
-  file_server
+	file_server
 }
 ```
 
 ```caddy
 {
-  auto_https disable_redirects
+	auto_https disable_redirects
 }
 
 # Alternatively provide explicit ports
 localhost:80, localhost:443 {
-  root * /usr/share/caddy
+	root * /usr/share/caddy
 
-  file_server
+	file_server
 }
 ```

--- a/src/docs/markdown/automatic-https.md
+++ b/src/docs/markdown/automatic-https.md
@@ -230,6 +230,7 @@ To get a wildcard from Let's Encrypt, you simply need to enable the [DNS challen
 Caddy implicitly uses the HTTPS port (default 443) for your [site addresses](/docs/conventions#network-addresses) that don't specify a port explicitly (which would disable automatic HTTPS). 
 
 Automatic HTTPS can be configured via the Caddyfile with the [`auto_https` global option](/docs/caddyfile/options), or via [per-server JSON configuration](/docs/json/apps/http/servers/automatic_https/). The Caddyfile option can be set to either of the following:
+
 - `disable_redirects` which disables the implicit HTTP->HTTPS redirect.
 - `off` which disables automatic HTTPS altogether, including the HTTP->HTTPS redirect and automatic enabling of TLS for sites that meet the requirements.
 
@@ -276,7 +277,7 @@ localhost:9000 {
 
 If you wish to serve content through both HTTP and HTTPS, without HTTP->HTTPS redirects, your site address must explicitly declare the intent to listen on both ports. To do so, [specify multiple site labels](/docs/caddyfile/concepts#addresses), separated by a comma or whitespace.
 
-HTTP and HTTPS by protocol, default ports can be configured via the Caddyfile [`http_port` and `https_port` global options](/docs/caddyfile/options):
+One way to do this is by specifying the protocol scheme, which infers the standard ports (the respective ports can be customized using [`http_port` and `https_port` global options](/docs/caddyfile/options)):
 
 ```caddy
 {

--- a/src/docs/markdown/automatic-https.md
+++ b/src/docs/markdown/automatic-https.md
@@ -227,7 +227,7 @@ To get a wildcard from Let's Encrypt, you simply need to enable the [DNS challen
 
 ## Examples
 
-Caddy implicitly uses the HTTPS port (default 443) for your [server addresses](/docs/conventions#network-addresses) that don't specify a port explicitly (which would disable automatic HTTPS). 
+Caddy implicitly uses the HTTPS port (default 443) for your [site addresses](/docs/conventions#network-addresses) that don't specify a port explicitly (which would disable automatic HTTPS). 
 
 Automatic HTTPS can be configured via the Caddyfile with the [`auto_https` global option](/docs/caddyfile/options), or via [per-server JSON configuration](/docs/json/apps/http/servers/automatic_https/). The Caddyfile option can be set to either of the following:
 - `disable_redirects` which disables the implicit HTTP->HTTPS redirect.
@@ -247,12 +247,13 @@ Automatic HTTPS can be configured via the Caddyfile with the [`auto_https` globa
 
 For local development environments, you can prevent serving via HTTPS by either specifying `http://` or providing a non-HTTPS port to disable per site, or by adding `auto_https off` to the Caddyfile global options which will change Caddy's implicit port to be the HTTP port (default 80).
 
+Have caddy implicitly use the HTTP port:
+
 ```caddy
 {
 	auto_https off
 }
 
-# Have caddy implicitly use the HTTP port
 localhost {
 	root * /usr/share/caddy
 
@@ -260,8 +261,9 @@ localhost {
 }
 ```
 
+Alternatively, provide an explicit port:
+
 ```caddy
-# Alternatively, provide an explicit port
 localhost:9000 {
 	root * /usr/share/caddy
 
@@ -272,17 +274,15 @@ localhost:9000 {
 
 ### HTTP and HTTPS without redirect
 
-If you want to serve content through both HTTP and HTTPS ports without HTTP redirects, your server address cannot rely on a single implicit port and you must explicitly declare the intent to listen from both ports.
+If you wish to serve content through both HTTP and HTTPS, without HTTP->HTTPS redirects, your site address must explicitly declare the intent to listen on both ports. To do so, [specify multiple site labels](/docs/caddyfile/concepts#addresses), separated by a comma or whitespace.
 
-To do so, you can [map several addresses to a site block as a list](/docs/caddyfile/concepts#addresses) separated with `,`:
+HTTP and HTTPS by protocol, default ports can be configured via the Caddyfile [`http_port` and `https_port` global options](/docs/caddyfile/options):
 
 ```caddy
 {
 	auto_https disable_redirects
 }
 
-# Uses the HTTP and HTTPS by protocol
-# These are configurable as global settings
 http://localhost, https://localhost {
 	root * /usr/share/caddy
 
@@ -290,12 +290,13 @@ http://localhost, https://localhost {
 }
 ```
 
+Alternatively specify the ports explicitly:
+
 ```caddy
 {
 	auto_https disable_redirects
 }
 
-# Alternatively provide explicit ports
 localhost:80, localhost:443 {
 	root * /usr/share/caddy
 

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -60,4 +60,4 @@ Possible options are:
 	- **interval** and **burst** allows `<n>` certificate operations within `<duration>` interval.
 - **local_certs** causes all certificates to be issued internally by default, rather than through a (public) ACME CA such as Let's Encrypt. This is useful in development environments.
 - **key_type** specifies the type of key to generate for TLS certificates; only change this if you have a specific need to customize it.
-- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`).
+- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). [Examples](/docs/automatic-https#examples).

--- a/src/docs/markdown/quick-starts/https.md
+++ b/src/docs/markdown/quick-starts/https.md
@@ -7,7 +7,9 @@ title: HTTPS quick-start
 This guide will show you how to get up and running with [fully-managed HTTPS](/docs/automatic-https) in no time.
 
 <aside class="tip">
-	Caddy uses HTTPS for all sites by default, as long as a host name is provided in the config. This tutorial assumes you want to get a publicly-trusted site (i.e. not "localhost") up over HTTPS, so we'll be using a public domain name and external ports.
+	Caddy uses HTTPS for all sites by default, as long as a host name is provided in the config. This tutorial assumes you want to get a publicly-trusted site (i.e. not "localhost") up over HTTPS, so we'll be using a public domain name and external ports. 
+
+	For a "localhost" setup, see examples [here](/docs/automatic-https#examples).
 </aside>
 
 **Prerequisites:**


### PR DESCRIPTION
My attempt to improve on the docs as a new Caddy user who got confused a bit with this feature, originally [raised an issue about it thinking I had run into a bug](https://github.com/caddyserver/caddy/issues/3635), but was due to Caddy defaulting to HTTPS with HTTP redirect implicitly, but only making a single port implicitly accessible (I assumed `disable_redirects` would keep HTTPS available but also HTTP just without the redirect).

Happy to iterate on feedback, I understand if it might be a bit too verbose or repetitive at present. I've also tried to expose a bit more discovery to related docs, as those who approach learning / experimentation the way I do may not have come across that info yet.

---

Not sure where [these JSON docs](https://caddyserver.com/docs/json/apps/http/servers/automatic_https/) are located, I take it they're not markdown? I was going to backlink to the main doc page on Automatic HTTPS. Not sure if JSON examples are necessary (Docs seem to prefer caddy snippets usually?).

I didn't see any contribution docs for the repo or style guide / linter, let me know if I need to make any changes regarding that. I think codefences are using tabs for indentation? I've used 2 spaces, but can change that if tabs are convention here.