### PR TITLE
docs: Add link from `auto_https` option to Auto HTTPS doc

### DIFF
--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -60,4 +60,4 @@ Possible options are:
 	- **interval** and **burst** allows `<n>` certificate operations within `<duration>` interval.
 - **local_certs** causes all certificates to be issued internally by default, rather than through a (public) ACME CA such as Let's Encrypt. This is useful in development environments.
 - **key_type** specifies the type of key to generate for TLS certificates; only change this if you have a specific need to customize it.
-- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). Check [Automatic HTTPS](/docs/automatic-https) for details on how these options affects http/https support.
+- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). See the [Automatic HTTPS](/docs/automatic-https) page for more details.

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -60,4 +60,4 @@ Possible options are:
 	- **interval** and **burst** allows `<n>` certificate operations within `<duration>` interval.
 - **local_certs** causes all certificates to be issued internally by default, rather than through a (public) ACME CA such as Let's Encrypt. This is useful in development environments.
 - **key_type** specifies the type of key to generate for TLS certificates; only change this if you have a specific need to customize it.
-- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`).
+- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). Check [Automatic HTTPS](/docs/automatic-https) for details on how these options affects http/https support.

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -60,4 +60,4 @@ Possible options are:
 	- **interval** and **burst** allows `<n>` certificate operations within `<duration>` interval.
 - **local_certs** causes all certificates to be issued internally by default, rather than through a (public) ACME CA such as Let's Encrypt. This is useful in development environments.
 - **key_type** specifies the type of key to generate for TLS certificates; only change this if you have a specific need to customize it.
-- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`).
+- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). If you choose `disable_redirects` port :80 won't be open unless a rule explicitelly listens to it on ingress.

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -60,4 +60,4 @@ Possible options are:
 	- **interval** and **burst** allows `<n>` certificate operations within `<duration>` interval.
 - **local_certs** causes all certificates to be issued internally by default, rather than through a (public) ACME CA such as Let's Encrypt. This is useful in development environments.
 - **key_type** specifies the type of key to generate for TLS certificates; only change this if you have a specific need to customize it.
-- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). If you choose `disable_redirects` port :80 won't be open unless a rule explicitelly listens to it on ingress.
+- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). If you choose `disable_redirects` or `off`, port :80 won't be open unless a rule explicitelly listens to it on ingress, for example, with `mysite.org:80`.

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -60,4 +60,4 @@ Possible options are:
 	- **interval** and **burst** allows `<n>` certificate operations within `<duration>` interval.
 - **local_certs** causes all certificates to be issued internally by default, rather than through a (public) ACME CA such as Let's Encrypt. This is useful in development environments.
 - **key_type** specifies the type of key to generate for TLS certificates; only change this if you have a specific need to customize it.
-- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). If you choose `disable_redirects` or `off`, port :80 won't be open unless a rule explicitelly listens to it on ingress, for example, with `mysite.org:80`.
+- **auto_https** configure automatic HTTPS. It can either disable it entirely (`off`) or disable only HTTP-to-HTTPS redirects (`disable_redirects`). Be aware that if you choose `disable_redirects` or `off`, port :80 won't be open unless a rule explicitelly listens to it on ingress, for example, with `mysite.org:80`.


### PR DESCRIPTION
It took 3h for me to make Caddy work on my machine because when I disabled redirects, I thought Caddy would serve my website using plain http, but this is not true, because Caddy won't event bind port :80 in this case unless you explicitly configure your site to work on port :80.


