### PR TITLE
docs: Clarify file imports are relative to current file, more cross-linking

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -82,7 +82,7 @@ If a request matches multiple site blocks, the site block with the most specific
 
 ### Directives
 
-**Directives** are keywords which customize how the site is served. For example, a complete file server config might look like this:
+[**Directives**](/docs/caddyfile/directives) are keywords which customize how the site is served. For example, a complete file server config might look like this:
 
 ```caddy
 localhost
@@ -98,7 +98,7 @@ localhost
 reverse_proxy localhost:9000
 ```
 
-In these examples, `file_server` and `reverse_proxy` are directives. Directives are the first word on a line in a site block.
+In these examples, [`file_server`](/docs/caddyfile/directives/file_server) and [`reverse_proxy`](/docs/caddyfile/directives/reverse_proxy) are directives. Directives are the first word on a line in a site block.
 
 In the second example, `localhost:9000` is an **argument** because it appears on the same line after the directive.
 
@@ -112,7 +112,7 @@ reverse_proxy localhost:9000 localhost:9001 {
 }
 ```
 
-Here, `lb_policy` is a subdirective to `reverse_proxy` (it sets the load balancing policy to use between backends).
+Here, `lb_policy` is a subdirective to [`reverse_proxy`](/docs/caddyfile/directives/reverse_proxy) (it sets the load balancing policy to use between backends).
 
 
 ### Tokens and quotes
@@ -271,7 +271,7 @@ And then you can reuse this anywhere you need:
 import redirect
 ```
 
-The `import` directive can also be used to include other files in its place. As a special case, it can appear almost anywhere within the Caddyfile.
+The [`import`](/docs/caddyfile/directives/import) directive can also be used to include other files in its place. As a special case, it can appear almost anywhere within the Caddyfile.
 
 
 

--- a/src/docs/markdown/caddyfile/directives/import.md
+++ b/src/docs/markdown/caddyfile/directives/import.md
@@ -14,7 +14,7 @@ This directive is a special case: it is evaluated before the structure is parsed
 import <pattern> [<args...>]
 ```
 
-- **&lt;pattern&gt;** is the filename, glob pattern, or name of [snippet](/docs/caddyfile/concepts#snippets) to include. Its contents will replace this line as if that file's contents appeared here to begin with. It is an error if a specific file cannot be found, but an empty glob pattern is not an error.
+- **&lt;pattern&gt;** is the filename, glob pattern, or name of [snippet](/docs/caddyfile/concepts#snippets) to include. Its contents will replace this line as if that file's contents appeared here to begin with. It is an error if a specific file cannot be found, but an empty glob pattern is not an error. If the pattern is a filename or glob, it is always relative to the file the `import` appears in.
 - **&lt;args...&gt;** is an optional list of arguments to pass to the imported tokens. They can be used with a placeholder of the form `{args.N}` where `N` is the 0-based positional index of the parameter. This placeholder is a special case and is evaluated at parse-time, not run-time.
 
 


### PR DESCRIPTION
See https://caddy.community/t/import-space-in-file-paths/9511 for the discussion where this was found to be unclear.