### PR TITLE
docs: Add links to Caddyfile directives in code blocks

### DIFF
--- a/src/includes/docs-head.html
+++ b/src/includes/docs-head.html
@@ -1,5 +1,10 @@
 {{include "/includes/head.html"}}
 <link rel="stylesheet" href="/resources/css/docs.css">
 <link rel="stylesheet" href="/resources/css/chroma.css">
+{{$directives := list }}
+{{range $i, $file := (listFiles "/docs/markdown/caddyfile/directives")}}
+    {{$directives = append $directives ($file | trimSuffix ".md")}}
+{{end}}
+<script type="text/javascript">window.CaddyfileDirectives = {{$directives | toJson}};</script>
 <script src="/resources/js/jquery-3.4.1.min.js"></script>
 <script src="/resources/js/docs.js"></script>

--- a/src/resources/js/docs.js
+++ b/src/resources/js/docs.js
@@ -30,4 +30,20 @@ $(function() {
 	// to the outer pre element, and our CSS file has a style to
 	// ensure the inner code block does not produce extra padding
 	$('article > pre:not(.chroma) > code:not(.cmd)').parent().addClass('chroma');
+
+	// Add links to Caddyfile directives in code blocks.
+	// See include/docs-head.html for the whitelist bootstrapping logic
+	$('pre.chroma .k')
+		.filter(function (k, item) {
+			return window.CaddyfileDirectives.includes(item.innerText);
+		})
+		.map(function(k, item) {
+			$(item).html(
+				'<a href="/docs/caddyfile/directives/' + item.innerText + '"'
+					+ 'style="color: inherit;"'
+				+ '>'
+					+ item.innerText
+				+ '</a>'
+			);
+		});
 });


### PR DESCRIPTION
This is super cool.

![image](https://user-images.githubusercontent.com/2111701/92301058-4c8c0400-ef2e-11ea-8f96-c19608166d64.png)

Basically, I make a whitelist based on the filenames of the `.md` files in the caddyfile directives directory, then inject that as JSON to `window.CaddyfileDirectives`... then on load in `docs.js`, I transform the `pre.chroma .k` elements, (`.k` is the class that happens to be the one that the chroma lexer spits out for directives, but also subdirectives) if their inner text matches that whitelist to be a link to the relevant page.

The links have no decorations by default (following the base CSS) but I add a `color: inherit;` style on these links so the colour is the same, and not a link colour. So these links are sorta invisible but you can hover on them to find out. Not the most discoverable thing ever, but it's not bad I think.