### PR TITLE
docs: Minor JSON docs bugfix for hiding a header, remove invalid comment

### DIFF
--- a/src/includes/docs-details.html
+++ b/src/includes/docs-details.html
@@ -10,7 +10,7 @@
 <div id="top-doc">
 	<!--Populated by JS-->
 </div>
-<h2 id="field-list">Field List</h2>
+<h2 id="field-list-header">Field List</h2>
 <dl id="field-list-contents">
 	<!--Populated by JS-->
 </dl>

--- a/src/resources/js/docs-api.js
+++ b/src/resources/js/docs-api.js
@@ -179,8 +179,8 @@ function beginRendering(json) {
 	renderData(pageData.structure, 0, "", $('<div class="group"/>'));
 	console.log("DOCS:", pageDocs);
 
-	if ($('#field-list-contents').html().trim()) {
-		$('#field-list').show();
+	if ($('#field-list-contents').text().trim()) {
+		$('#field-list-header').show();
 	}
 
 	// if the browser tried to navigate directly to an element

--- a/src/resources/js/docs.js
+++ b/src/resources/js/docs.js
@@ -50,9 +50,8 @@ $(function() {
 		});
 
 	// Add links to [<matcher>] or named matcher tokens in code blocks.
-	// We can't do it exactly the same as the above block, because
-	// the matcher text includes <> character which are parsed as HTML
-	// unless we use text() to change the link text.
+	// The matcher text includes <> characters which are parsed as HTML,
+	// so we must use text() to change the link text.
 	$('pre.chroma .nd')
 		.map(function(k, item) {
 			let text = item.innerText;


### PR DESCRIPTION
Nothing fancy here, just some minor fixes :smile: 

Also updated the Caddyfile so that testing the JSON docs and the download page is a bit easier, by proxying to the real site for the underlying data (easier for people who aren't @mholt I guess :smile:)