### PR TITLE
docs: clarify that default log format is console if TTY, otherwise JSON

### DIFF
--- a/src/docs/markdown/caddyfile/directives/log.md
+++ b/src/docs/markdown/caddyfile/directives/log.md
@@ -17,7 +17,7 @@ log {
 ```
 
 - **output** configures a where to write the logs to. See [Output modules](#output-modules) below. Default: `stderr`
-- **format** describes how to encode, or format, the logs. See [Format modules](#format-modules) below. Default `console`
+- **format** describes how to encode, or format, the logs. See [Format modules](#format-modules) below. Default: `console` if `stdout` is detected to be a terminal, `json` otherwise.
 - **level** is the minimum entry level to log. Default: `INFO`
 
 ### Output modules


### PR DESCRIPTION
fixes https://github.com/caddyserver/website/issues/88