### PR TITLE
docs: add x-forwarded-for note to remote_ip documentation

### DIFF
--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -434,7 +434,7 @@ query sort=asc
 remote_ip <ranges...>
 ```
 
-By remote (client) IP address. Accepts exact IPs or CIDR ranges.
+By remote (client) IP address. If `X-Forwarded-For` is passed in request headers, this will be used for remote IP address. Accepts exact IPs or CIDR ranges
 
 #### Example:
 

--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -434,7 +434,7 @@ query sort=asc
 remote_ip <ranges...>
 ```
 
-By remote (client) IP address. If `X-Forwarded-For` is passed in request headers, this will be used for remote IP address. Accepts exact IPs or CIDR ranges
+By remote (client) IP address. If `X-Forwarded-For` is passed in request headers, this will be used for remote IP address. Accepts exact IPs or CIDR ranges.
 
 #### Example:
 


### PR DESCRIPTION
Just a quick clarifying note that remote_ip will use X-Forwarded-For header if it's included in remote headers.