### PR TITLE
small typo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -385,7 +385,7 @@
 					<div class="feature">
 						<h5>JSON Structure</h5>
 						<p>
-							Caddy's native config format is JSON, so it is familiar and highly interoperable with exising systems and tools.
+							Caddy's native config format is JSON, so it is familiar and highly interoperable with existing systems and tools.
 						</p>
 					</div>
 					<div class="feature">


### PR DESCRIPTION
There was a small typo on the main page.

`exising` --> `existing`