### PR TITLE
Replaced http.cat example with single line respond

### DIFF
--- a/src/docs/markdown/caddyfile/directives/handle_errors.md
+++ b/src/docs/markdown/caddyfile/directives/handle_errors.md
@@ -53,3 +53,11 @@ handle_errors {
 	}
 }
 ```
+
+Simply use [`respond`](/docs/caddyfile/directives/respond) to return the error code and name
+
+```caddy
+handle_errors {
+	respond "{http.error.status_code} {http.error.status_text}"
+}
+```

--- a/src/docs/markdown/caddyfile/directives/handle_errors.md
+++ b/src/docs/markdown/caddyfile/directives/handle_errors.md
@@ -48,6 +48,8 @@ Reverse proxy to a professional server that is highly qualified for handling HTT
 ```caddy
 handle_errors {
 	rewrite * /{http.error.status_code}
-	reverse_proxy https://http.cat
+	reverse_proxy https://http.cat {
+		header_up Host http.cat
+	}
 }
 ```


### PR DESCRIPTION
The http.cat example did not work for me, and I found that using a simple respond with {http.error.status_code} {http.error.status_text} gives a good way to make errors handled, without having to delve into templates or making a page for each error code

If you would rather keep the http.cat example and just add mine, sure.
The behaviour from my example could also be implemented by default, instead of showing a blank empty page to the user. But that's a story for another day.