### PR TITLE
docs: Mention the auth placeholder in basicauth docs

### DIFF
--- a/src/docs/markdown/caddyfile/directives/basicauth.md
+++ b/src/docs/markdown/caddyfile/directives/basicauth.md
@@ -12,6 +12,8 @@ When a user requests a resource that is protected, the browser will prompt the u
 
 Caddy configuration does not accept plaintext passwords; you MUST hash them before putting them into the configuration. The [`caddy hash-password`](/docs/command-line#caddy-hash-password) command can help with this.
 
+After a successful authentication, the `{http.auth.user.id}` placeholder will be available, which contains the authenticated username.
+
 
 ## Syntax
 


### PR DESCRIPTION
https://caddy.community/t/placeholder-for-username-of-basicauth-user/10606