### PR TITLE
docs: Update reverse_proxy examples

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -249,16 +249,16 @@ Configure some transport options:
 reverse_proxy https://example.com {
 	transport http {
 		dial_timeout 2s
-		tls_timeout 2s
+		tls_timeout  2s
 	}
 }
 ```
 
-Strip a path prefix then proxy with a new path:
+Replace a path prefix before proxying:
 
 ```caddy-d
-handle_path /prefix/* {
-	rewrite * /foo{path}
+handle_path /old-prefix/* {
+	rewrite * /new-prefix{path}
 	reverse_proxy localhost:9000
 }
 ```

--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -243,11 +243,22 @@ Reverse proxy to an HTTPS endpoint:
 reverse_proxy https://example.com
 ```
 
-Strip a path prefix then proxy:
+Configure some transport options:
 
 ```caddy-d
-route /prefix/* {
-	uri strip_prefix /prefix
+reverse_proxy https://example.com {
+	transport http {
+		dial_timeout 2s
+		tls_timeout 2s
+	}
+}
+```
+
+Strip a path prefix then proxy with a new path:
+
+```caddy-d
+handle_path /prefix/* {
+	rewrite * /foo{path}
 	reverse_proxy localhost:9000
 }
 ```


### PR DESCRIPTION
- `route + uri strip_prefix` -> `handle_path`, plus add a rewrite example (as in replace the prefix type of pattern)
- Add an example that uses `transport` cause it might not be immediately obvious how to use for beginners