### PR TITLE
docs: Update url in index.html to fix 404

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -603,7 +603,7 @@
 					<div class="feature">
 						<h5>Redirect HTTP to HTTPS</h5>
 						<p>
-							Caddy's <a href="/v1/docs/automatic-https">automatic HTTPS</a> feature includes redirecting HTTP to HTTPS for you by default.
+							Caddy's <a href="/docs/automatic-https">automatic HTTPS</a> feature includes redirecting HTTP to HTTPS for you by default.
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
This url gives a 404, can be fixed by removing the /v1/.