### PR TITLE
metrics: Document the disable_openmetrics option

### DIFF
--- a/src/docs/markdown/caddyfile/directives/metrics.md
+++ b/src/docs/markdown/caddyfile/directives/metrics.md
@@ -11,7 +11,7 @@ Note that a `/metrics` endpoint is also attached to the [admin API](/docs/api),
 which is not configurable, and is not available when the admin API is disabled.
 
 This endpoint will return metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format)
-or, if negotiated, in the [OpenMetrics exposition format](https://pkg.go.dev/github.com/prometheus/client_golang@v1.7.1/prometheus/promhttp#HandlerOpts)
+or, if negotiated, in the [OpenMetrics exposition format](https://pkg.go.dev/github.com/prometheus/client_golang@v1.9.0/prometheus/promhttp#HandlerOpts)
 (`application/openmetrics-text`).
 
 See also [Monitoring Caddy with Prometheus metrics](/docs/metrics).
@@ -19,8 +19,13 @@ See also [Monitoring Caddy with Prometheus metrics](/docs/metrics).
 ## Syntax
 
 ```caddy-d
-metrics [<matcher>]
+metrics [<matcher>] {
+	disable_openmetrics
+}
 ```
+
+- **disable_openmetrics** disables OpenMetrics negotiation. Usually not 
+  necessary except when needing to work around parsing bugs.
 
 ## Examples
 
@@ -41,5 +46,13 @@ Serve metrics at a separate subdomain:
 ```caddy
 metrics.example.com {
 	metrics
+}
+```
+
+Disable OpenMetrics negotiation:
+
+```caddy-d
+metrics /metrics {
+	disable_openmetrics
 }
 ```


### PR DESCRIPTION
Docs for new option added in https://github.com/caddyserver/caddy/pull/3944

Signed-off-by: Dave Henderson <dhenderson@gmail.com>