### PR TITLE
docs: explain how to disable FLoC

### DIFF
--- a/src/docs/markdown/caddyfile/directives/header.md
+++ b/src/docs/markdown/caddyfile/directives/header.md
@@ -51,10 +51,13 @@ Replace `http://` with `https://` in any Location header:
 header Location http:// https://
 ```
 
-Set security headers on all pages: (**WARNING:** only use if you understand the implications!)
+Set security and privacy headers on all pages: (**WARNING:** only use if you understand the implications!)
 
 ```caddy-d
 header {
+	# disable FLoC tracking
+	Permissions-Policy interest-cohort=()
+
 	# enable HSTS
 	Strict-Transport-Security max-age=31536000;
 


### PR DESCRIPTION
Google’s Federated Learning of Cohorts is a new initiative to track internet users without their consent. This feature is already enabled by default for a small percentage of Google Chrome users, and is intended to be enabled for all users at the end of the experiment.
Developers can opt their websites out of FLoC by setting this HTTP header: `Permissions-Policy: interest-cohort=()`.

This PR explains how to do this with Caddy.
 
For more information about FLoC read [Google’s FLoC Is a Terrible Idea](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea) by @EFForg and [How to fight back against Google FLoC](https://plausible.io/blog/google-floc) by @plausible.

Similar to https://github.com/api-platform/api-platform/pull/1879.