### PR TITLE
docs: Warn about the behaviour of `?` in multi-line `header` handlers

### DIFF
--- a/src/docs/markdown/caddyfile/directives/header.md
+++ b/src/docs/markdown/caddyfile/directives/header.md
@@ -6,13 +6,13 @@ title: header (Caddyfile directive)
 
 Manipulates HTTP header fields on the response. It can set, add, and delete header values, or perform replacements using regular expressions.
 
-By default, header operations are performed immediately unless any of the headers are being deleted, in which case the header operations are automatically deferred until the time they are being written to the client.
+By default, header operations are performed immediately unless any of the headers are being deleted, or attempting to set a defualt value. In that case, the header operations are automatically deferred until the time they are being written to the client.
 
 
 ## Syntax
 
 ```caddy-d
-header [<matcher>] [[+|-|?]<field> [<value>|<find>] [<replace>]] {
+header [<matcher>] [[+|-|?]<field> [<value>|<find>|<default_value>] [<replace>]] {
 	<field> <find> <replace>
 	[+]<field> <value>
 	-<field>
@@ -26,9 +26,11 @@ header [<matcher>] [[+|-|?]<field> [<value>|<find>] [<replace>]] {
 - **&lt;default_value&gt;** is the header field value that will be set only if the header does not already exist.
 - **&lt;find&gt;** is the substring or regular expression to search for.
 - **&lt;replace&gt;** is the replacement value; required if performing a search-and-replace.
-- **defer** will force the header operations to be deferred until the response is written out to the client. This is automatically enabled if any of the header fields are being deleted.
+- **defer** will force the header operations to be deferred until the response is being written out to the client. This is automatically enabled if any of the header fields are being deleted with `-`, or when attempting to set a default value with `?`.
 
 For multiple header manipulations, you can open a block and specify one manipulation per line in the same way.
+
+When using the `?` prefix to set a default header value, it is recommended to separate this into its own `header` handler, because under the hood, it works by configuring a response matcher which applies to the entire handler, to decide whether a header operation should be performed (i.e. when the given header field is empty). For example, if in the same handler (using multi-line syntax) you have these two manipulations: `-Hidden` and `?Foo default`, then the `Hidden` header is _only_ removed if `Foo` is empty, which is typically not the intended effect.
 
 
 ## Examples

--- a/src/docs/markdown/caddyfile/directives/header.md
+++ b/src/docs/markdown/caddyfile/directives/header.md
@@ -6,7 +6,7 @@ title: header (Caddyfile directive)
 
 Manipulates HTTP header fields on the response. It can set, add, and delete header values, or perform replacements using regular expressions.
 
-By default, header operations are performed immediately unless any of the headers are being deleted, or attempting to set a defualt value. In that case, the header operations are automatically deferred until the time they are being written to the client.
+By default, header operations are performed immediately unless any of the headers are being deleted (`-` prefix) or setting a defualt value (`?` prefix). In those cases, the header operations are automatically deferred until the time they are being written to the client.
 
 
 ## Syntax
@@ -26,11 +26,11 @@ header [<matcher>] [[+|-|?]<field> [<value>|<find>|<default_value>] [<replace>]]
 - **&lt;default_value&gt;** is the header field value that will be set only if the header does not already exist.
 - **&lt;find&gt;** is the substring or regular expression to search for.
 - **&lt;replace&gt;** is the replacement value; required if performing a search-and-replace.
-- **defer** will force the header operations to be deferred until the response is being written out to the client. This is automatically enabled if any of the header fields are being deleted with `-`, or when attempting to set a default value with `?`.
+- **defer** will force the header operations to be deferred until the response is being written out to the client. This is automatically enabled if any of the header fields are being deleted with `-`, or when setting a default value with `?`.
 
 For multiple header manipulations, you can open a block and specify one manipulation per line in the same way.
 
-When using the `?` prefix to set a default header value, it is recommended to separate this into its own `header` handler, because under the hood, it works by configuring a response matcher which applies to the entire handler, to decide whether a header operation should be performed (i.e. when the given header field is empty). For example, if in the same handler (using multi-line syntax) you have these two manipulations: `-Hidden` and `?Foo default`, then the `Hidden` header is _only_ removed if `Foo` is empty, which is typically not the intended effect.
+When using the `?` prefix to set a default header value, it is recommended to separate this into its own `header` directive. [Under the hood](https://caddyserver.com/docs/modules/http.handlers.headers#response/require), using `?` configures a response matcher which applies to the directive's entire handler which only applies the header operations if the field is not yet set. For example, if in the same directive, you have these two manipulations: `-Hidden` and `?Foo default`, then the `Hidden` header is _only_ removed if `Foo` is empty, which is typically not the intended effect.
 
 
 ## Examples


### PR DESCRIPTION
Fixes https://github.com/caddyserver/caddy/issues/4130