### PR TITLE
docs: Clarify `file_server` behaviour inside `handle_errors`

### DIFF
--- a/src/docs/markdown/caddyfile/directives/handle_errors.md
+++ b/src/docs/markdown/caddyfile/directives/handle_errors.md
@@ -29,7 +29,7 @@ handle_errors {
 
 ## Examples
 
-Custom error pages based on the status code (i.e. a page called `404.html` for 404 errors):
+Custom error pages based on the status code (i.e. a page called `404.html` for 404 errors). Note that [`file_server`](file_server) preserves the error's HTTP status code when run in `handle_errors`:
 
 ```caddy-d
 handle_errors {


### PR DESCRIPTION
This was part of https://github.com/caddyserver/website/pull/154 which was incorrect, but I realized I had this part in it which is still relevant to keep.