### PR TITLE
 Added documentation for import arguments

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -284,11 +284,6 @@ You can pass arguments to imported configuration and use them like so:
     output file /var/log/caddy/{args.0}.access.log
   }
 }
-```
-
-And then you can reuse it anywhere with parameters: 
-
-```caddy-d
 a.example.com {
   import log_common a.example.com
 }

--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -276,6 +276,27 @@ import redirect
 
 The [`import`](/docs/caddyfile/directives/import) directive can also be used to include other files in its place. As a special case, it can appear almost anywhere within the Caddyfile.
 
+The [`import`](/docs/caddyfile/directives/import) directive supports the arguments :
+
+```caddy
+(log_common) {
+  log {
+    output file /var/log/caddy/{args.0}.access.log
+  }
+}
+```
+
+And then you can reuse it anywhere with parameters: 
+
+```caddy-d
+a.example.com {
+  import log_common a.example.com
+}
+
+b.example.com {
+  import log_common b.example.com
+}
+```
 
 
 ## Comments

--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -276,7 +276,7 @@ import redirect
 
 The [`import`](/docs/caddyfile/directives/import) directive can also be used to include other files in its place. As a special case, it can appear almost anywhere within the Caddyfile.
 
-The [`import`](/docs/caddyfile/directives/import) directive supports the arguments :
+You can pass arguments to imported configuration and use them like so:
 
 ```caddy
 (log_common) {

--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -279,17 +279,16 @@ The [`import`](/docs/caddyfile/directives/import) directive can also be used to 
 You can pass arguments to imported configuration and use them like so:
 
 ```caddy
-(log_common) {
-  log {
-    output file /var/log/caddy/{args.0}.access.log
-  }
+(snippet) {
+  respond "Yahaha! You found {args.0}!"
 }
+
 a.example.com {
-  import log_common a.example.com
+	import snippet "Example A"
 }
 
 b.example.com {
-  import log_common b.example.com
+	import snippet "Example B"
 }
 ```
 


### PR DESCRIPTION
Hi,

This PR add documentation for arguments in snippet,. Otherwise the only mention is in the description of the import directive, and the PR : https://github.com/caddyserver/caddy/pull/3423

Thank you !