### PR TITLE
docs: A few fixes, one more example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/encode.md
+++ b/src/docs/markdown/caddyfile/directives/encode.md
@@ -30,7 +30,7 @@ encode [<matcher>] <formats...> {
 - **gzip** enables Gzip compression, optionally at the specified level.
 - **zstd** enables Zstandard compression.
 - **minimum_length** the minimum number of bytes a response should have to be encoded (default: 512).
-- **match** is a [Response matcher](#responsematcher). Only matching Responses are encoded. The default looks like this:
+- **match** is a [response matcher](#response-matcher). Only matching responses are encoded. The default looks like this:
 
   ```caddy-d
   match {
@@ -60,7 +60,7 @@ By HTTP status code.
 
 ### header
 
-See Request matcher [header](/docs/caddyfile/matchers#header).
+See the [header](/docs/caddyfile/matchers#header) request matcher for the supported syntax.
 
 ## Examples
 

--- a/src/docs/markdown/caddyfile/patterns.md
+++ b/src/docs/markdown/caddyfile/patterns.md
@@ -128,7 +128,7 @@ redir /remove/ /remove
 Using a redirect, the client will have to re-issue the request, enforcing a single acceptable URI for a resource.
 
 
-### Wildcard certificates
+## Wildcard certificates
 
 If you need to serve multiple subdomains with the same wildcard certificate, the best way to handle them is with a Caddyfile like this, making use of the [`handle`](/docs/caddyfile/directives/handle) directive and [`host`](/docs/caddyfile/matchers#host) matchers:
 


### PR DESCRIPTION
- Change wildcard certs patterns from h3 to h2 header
- Clean up `encode.md` a bit
- Add TOC entry for `handle_response`
- Add response matcher docs for `handle_response` (copied from `encode.md`)
- Add example for `handle_response` for handling by status code