### PR TITLE
docs: Fix example of rewrite in handle_response

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -363,7 +363,7 @@ reverse_proxy localhost:8080 {
 	@error status 500 503
 	handle_response @error {
 		root    * /path/to/error/pages
-		rewrite   /{http.reverse_proxy.status_code}.html
+		rewrite * /{http.reverse_proxy.status_code}.html
 		file_server
 	}
 }


### PR DESCRIPTION
See: https://caddy.community/t/module-not-registered-http-matchers-status-when-trying-to-intercept-responses/12470/6