### PR TITLE
Add a space between the icon and href in the card.

### DIFF
--- a/src/resources/js/download.js
+++ b/src/resources/js/download.js
@@ -25,7 +25,7 @@ $.get("/api/packages").done(function(json) {
 
 		const moduleTemplate =
 			'<div class="module">\n'+
-			'	&#128268;<a target="_blank" title="View module docs" class="module-link"></a>\n'+
+			'	&#128268; <a target="_blank" title="View module docs" class="module-link"></a>\n'+
 			'	<span class="module-desc"></span>\n'+
 			'</div>\n';
 


### PR DESCRIPTION
Add a space between the module icon and the module link is clearer imo.

e.g.
![Capture d’écran 2021-05-29 à 01 05 11](https://user-images.githubusercontent.com/25440709/120049570-b13a4200-c01a-11eb-968d-1733a5da3e3d.png)

![Capture d’écran 2021-05-29 à 01 10 25](https://user-images.githubusercontent.com/25440709/120049574-b4cdc900-c01a-11eb-9513-c055ff63af77.png)
