### PR TITLE
Docs for `preferred_chains` issuer and global config

### DIFF
--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -118,6 +118,10 @@ Obtains certificates using the ACME protocol.
 	trusted_roots <pem_files...>
 	dns <provider_name> [<options>]
 	resolvers <dns_servers...>
+	preferred_chains [smallest] {
+		root_common_name <common_names...>
+		any_common_name  <common_names...>
+	}
 }
 ```
 
@@ -134,6 +138,10 @@ Obtains certificates using the ACME protocol.
 - **trusted_roots** is one or more root certificates (as PEM filenames) to trust when connecting to the ACME CA server.
 - **dns** configures the DNS challenge.
 - **resolvers** customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones.
+- **preferred_chains** specifies which certificate chains Caddy should prefer; useful if your CA provides multiple chains. Use one of the following options:
+	- **smallest** will tell Caddy to prefer chains with the fewest amount of bytes.
+	- **root_common_name** is a list of one or more common names; Caddy will choose the first chain that has a root that matches with at least one of the specified common names.
+	- **any_common_name** is a list of one or more common names; Caddy will choose the first chain that has an issuer that matches with at least one of the specified common names.
 
 
 #### zerossl

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -59,6 +59,10 @@ Possible options are:
 	key_type ed25519|p256|p384|rsa2048|rsa4096
 	cert_issuer <name> ...
 	ocsp_stapling off
+	preferred_chains [smallest] {
+		root_common_name <common_names...>
+		any_common_name  <common_names...>
+	}
 
 	# Server Options
 	servers [<listener_address>] {
@@ -166,6 +170,14 @@ Defines the issuer (or source) of TLS certificates. The tokens following the nam
 ##### `ocsp_stapling`
 Can be set to `off` to disable OCSP stapling. Useful in environments where responders are not reachable due to firewalls.
 
+##### `preferred_chains`
+If your CA provides multiple certificate chains, you can use this option to specify which chain Caddy should prefer. Set one of the following options:
+
+- **smallest** will tell Caddy to prefer chains with the fewest amount of bytes.
+- **root_common_name** is a list of one or more common names; Caddy will choose the first chain that has a root that matches with at least one of the specified common names.
+- **any_common_name** is a list of one or more common names; Caddy will choose the first chain that has an issuer that matches with at least one of the specified common names.
+
+Note! Specifying `preferred_chains` as a global option will affect all issuers if there isn't any [overriding issuer level config](/docs/caddyfile/directives/tls#acme).
 
 
 ## Server Options


### PR DESCRIPTION
Added docs for the `preferred_chains` option that was added to Caddyfile.

Ref. caddyserver/caddy#4192