### PR TITLE
docs: Add `propagation_timeout` to tls issuer options

### DIFF
--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -117,6 +117,7 @@ Obtains certificates using the ACME protocol.
 	eab <key_id> <mac_key>
 	trusted_roots <pem_files...>
 	dns <provider_name> [<options>]
+	propagation_timeout <duration>
 	resolvers <dns_servers...>
 	preferred_chains [smallest] {
 		root_common_name <common_names...>
@@ -137,6 +138,7 @@ Obtains certificates using the ACME protocol.
 - **eab** specifies an External Account Binding which may be required with some ACME CAs.
 - **trusted_roots** is one or more root certificates (as PEM filenames) to trust when connecting to the ACME CA server.
 - **dns** configures the DNS challenge.
+- **propagation_timeout** is a [duration value](/docs/conventions#durations) that sets how long to wait for DNS TXT records to propagate. Default 2 minutes.
 - **resolvers** customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones.
 - **preferred_chains** specifies which certificate chains Caddy should prefer; useful if your CA provides multiple chains. Use one of the following options:
 	- **smallest** will tell Caddy to prefer chains with the fewest amount of bytes.


### PR DESCRIPTION
Added in https://github.com/caddyserver/caddy/pull/4178