### PR TITLE
docs: Add additional example to the `respond` directive

### DIFF
--- a/src/docs/markdown/caddyfile/directives/respond.md
+++ b/src/docs/markdown/caddyfile/directives/respond.md
@@ -49,3 +49,8 @@ respond /secret/* "Access denied" 403 {
 	close
 }
 ```
+
+To respond with a body containing double quotes, which would need escaping, you can make use of [backticks](/docs/caddyfile/concepts#tokens-and-quotes) to avoid escaping:
+```caddy-d
+respond `{"key": "value"}`
+```


### PR DESCRIPTION
I always try to read all the examples on the docs to get a better understanding of what can be done and how it can be done.
Unbeknownst to me I could use backticks as delimiters to "escape" the escaping of characters which would need them otherwise.

Reference: https://twitter.com/mholt6/status/1407473895876136962

This PR adds an additional example which highlights this. I bet others will find this interesting and could benefit from it.