### PR TITLE
Add instruction on how to run Caddy as a Windows service

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -29,6 +29,7 @@ This page describes various methods for installing Caddy on your system.
 - [Ansible](#ansible)
 - [Scoop](#scoop)
 - [Termux](#termux)
+- [Windows service](#windows-service)
 
 
 ## Static binaries
@@ -222,4 +223,52 @@ _Note: This is a community-maintained installation method._
 <pre><code class="cmd">pkg install caddy</code></pre>
 
 [**View the Termux build.sh file**](https://github.com/termux/termux-packages/blob/master/packages/caddy/build.sh)
+
+
+## Windows service
+
+_Note: This is a community-maintained installation method._
+
+Install Caddy as a service on Windows with these instructions.
+
+**Requirements:**
+
+- `caddy.exe` binary that you [downloaded](/download) or [built from source](/docs/build)
+- Any exe from the latest release of the
+  [WinSW](https://github.com/winsw/winsw/releases/latest) service wrapper (Stay
+  on a v2.x release for now)
+
+Put all files into a service directory. In the following examples, we use `c:\caddy`.
+
+Rename the WinSW exe file to `caddy-service.exe`.
+
+Add a `caddy-service.xml` in the directory:
+
+<pre><code class="cmd">&lt;service>
+  &lt;id>caddy&lt;/id>
+  &lt;!-- Display name of the service -->
+  &lt;name>Caddy Web Server (powered by WinSW)&lt;/name>
+  &lt;!-- Service description -->
+  &lt;description>Caddy Web Server (https://caddyserver.com/)&lt;/description>
+  &lt;executable>%BASE%\caddy.exe&lt;/executable>
+  &lt;arguments>run&lt;/arguments>
+  &lt;log mode="roll-by-time">
+    &lt;pattern>yyyy-MM-dd&lt;/pattern>
+  &lt;/log>
+&lt;/service>
+</code></pre>
+
+You can now install the service using:
+<pre><code class="cmd">caddy-service install</code></pre>
+
+You might want to start the Windows Services Console to see if the service is runnnig correctly:
+<pre><code class="cmd">services.msc</code></pre>
+
+Be aware that Windows services cannot be reloaded, so you have to tell caddy directly to relaod:
+<pre><code class="cmd">caddy reload</code></pre>
+
+Restarting is possible via the normal Windows services commands.
+
+For customizing the service wrapper, see the [WinSW documentation](https://github.com/winsw/winsw/tree/master#usage)
+
 


### PR DESCRIPTION
This is a first stab at getting some simple instructions on how to run Caddy as a Windows service into the official doumentation.

Some things:
- Maybe put the XML file into https://github.com/caddyserver/dist somewhere?
- [WinSW](https://github.com/winsw/winsw/tree/master#usage) supports a stop command, but I noticed that `caddy stop` might not be universal if, for example, the admin port was changed. Leaving it out, caddy just receives a SIGINT from the service wrapper:
```json
{"level":"info","ts":1624970636.3611643,"msg":"shutting down","signal":"SIGINT"}
{"level":"warn","ts":1624970636.3611643,"msg":"exiting; byeee!! ðŸ‘‹","signal":"SIGINT"}
{"level":"info","ts":1624970636.3984616,"msg":"shutdown complete","signal":"SIGINT","exit_code":0}
```
- WinSW redirects STDERR & STDOUT into files, as a simple suggestion this is configured to roll daily. If caddy isn't writing that much to STDERR, it might be better to roll weekly or monthly?