### PR TITLE
docs: reverse_proxy typo "tranport" -> "transport"

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -15,7 +15,7 @@ Proxies requests to one or more backends with configurable transport, load balan
 - [Headers](#headers)
 - [Transports](#transports)
   - [The `http` transport](#the-http-transport)
-  - [The `fastcgi` tranport](#the-fastcgi-transport)
+  - [The `fastcgi` transport](#the-fastcgi-transport)
 - [Intercepting responses](#intercepting-responses)
 - [Examples](#examples)
 


### PR DESCRIPTION
The reverse_proxy directive docs contained a TOC featuring the line "The fastcgi tranport". Changed "tranport" to "transport".