### PR TITLE
Use correct response header in CORS example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/import.md
+++ b/src/docs/markdown/caddyfile/directives/import.md
@@ -32,7 +32,7 @@ Import a snippet that sets CORS headers using an import argument:
 (cors) {
 	@origin header Origin {args.0}
 	header @origin Access-Control-Allow-Origin "{args.0}"
-	header @origin Access-Control-Request-Method GET
+	header @origin Access-Control-Allow-Methods "OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE"
 }
 
 example.com {


### PR DESCRIPTION
`Access-Control-Request-Method` is a request header
sent by the client (browser, ...) but we need to send
response header with all allowed methods.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods

----------------------------

Also, I was not able to include `import cors` multiple times like this but I found out a solution. I can add it in the new commit if needed.

```
(cors) {
	@origin{args.0} header Origin {args.0}
	header @origin{args.0} Access-Control-Allow-Origin "{args.0}"
	header @origin{args.0} Access-Control-Request-Method GET
	header @origin{args.0} Access-Control-Allow-Methods "OPTIONS,HEAD,GET,POST,PUT,PATCH,DELETE"
}
example.com {
	import cors example.com
	import cors another.example.com
}
```