### PR TITLE
docs: Dynamically turn subdirectives into links to anchors

### DIFF
--- a/src/docs/markdown/caddyfile/directives.md
+++ b/src/docs/markdown/caddyfile/directives.md
@@ -2,9 +2,36 @@
 title: Caddyfile Directives
 ---
 
+<style>
+#directive-table table {
+	margin: 0 auto;
+	overflow: hidden;
+}
+
+#directive-table tr:hover {
+	background: rgba(0, 0, 0, 10%);
+}
+
+#directive-table tr td:first-child {
+	position: relative;
+}
+
+#directive-table a:before {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	display: block;
+	width: 100vw;
+}
+</style>
+
 # Caddyfile Directives
 
 The following directives come standard with Caddy, and can be used in the HTTP Caddyfile:
+
+<div id="directive-table">
 
 Directive | Description
 ----------|------------
@@ -38,6 +65,7 @@ Directive | Description
 **[try_files](/docs/caddyfile/directives/try_files)** | Rewrite that depends on file existence
 **[uri](/docs/caddyfile/directives/uri)** | Manipulate the URI
 
+</div>
 
 ## Syntax
 

--- a/src/docs/markdown/caddyfile/directives/encode.md
+++ b/src/docs/markdown/caddyfile/directives/encode.md
@@ -2,6 +2,13 @@
 title: encode (Caddyfile directive)
 ---
 
+<script>
+$(function() {
+	// We'll add links to all the subdirectives if a matching anchor tag is found on the page.
+	addLinksToSubdirectives();
+});
+</script>
+
 # encode
 
 Encodes responses using the configured encoding(s). A typical use for encoding is compression.
@@ -27,10 +34,10 @@ encode [<matcher>] <formats...> {
 ```
 
 - **&lt;formats...&gt;** is the list of encoding formats to enable. If multiple encodings are enabled, the encoding is chosen based the request's Accept-Encoding header; if the client has no strong preference (q-factor), then the first supported encoding is used.
-- **gzip** enables Gzip compression, optionally at the specified level.
-- **zstd** enables Zstandard compression.
-- **minimum_length** the minimum number of bytes a response should have to be encoded (default: 512).
-- **match** is a [response matcher](#response-matcher). Only matching responses are encoded. The default looks like this:
+- **gzip** <span id="gzip"/> enables Gzip compression, optionally at the specified level.
+- **zstd** <span id="zstd"/> enables Zstandard compression.
+- **minimum_length** <span id="minimum_length"/> the minimum number of bytes a response should have to be encoded (default: 512).
+- **match** <span id="match"/> is a [response matcher](#response-matcher). Only matching responses are encoded. The default looks like this:
 
   ```caddy-d
   match {

--- a/src/docs/markdown/caddyfile/directives/log.md
+++ b/src/docs/markdown/caddyfile/directives/log.md
@@ -2,6 +2,13 @@
 title: log (Caddyfile directive)
 ---
 
+<script>
+$(function() {
+	// We'll add links to all the subdirectives if a matching anchor tag is found on the page.
+	addLinksToSubdirectives();
+});
+</script>
+
 # log
 
 Enables and configures HTTP request logging (also known as access logs).
@@ -101,7 +108,7 @@ output net <address> {
 ```
 
 - **&lt;address&gt;** is the [address](/docs/conventions#network-addresses) to write logs to.
-- **&lt;dial_timeout&gt;** is how long to wait for a successful connection to the log socket. Log emissions may be blocked for up to this long if the socket goes down.
+- **dial_timeout** is how long to wait for a successful connection to the log socket. Log emissions may be blocked for up to this long if the socket goes down.
 
 
 

--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -2,6 +2,28 @@
 title: reverse_proxy (Caddyfile directive)
 ---
 
+<script>
+$(function() {
+	// Fix response matchers to render with the right color,
+	// and link to response matchers section
+	$('pre.chroma .k:contains("@")')
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			let url = '#' + item.innerText.replace(/_/g, "-");
+			$(item).addClass('nd').removeClass('k')
+			$(item).html('<a href="#response-matcher" style="color: inherit;" title="Response matcher">' + text + '</a>');
+		});
+	
+	// Fix matcher placeholder
+	$('pre.chroma .k:contains("handle_response")').first().nextAll().slice(0, 3)
+		.wrapAll('<span class="nd">').parent()
+		.html('<a href="#response-matcher" style="color: inherit;" title="Response matcher">[&lt;matcher&gt;]</a>')
+
+	// We'll add links to all the subdirectives if a matching anchor tag is found on the page.
+	addLinksToSubdirectives();
+});
+</script>
+
 # reverse_proxy
 
 Proxies requests to one or more backends with configurable transport, load balancing, health checking, header manipulation, and buffering options.
@@ -83,7 +105,7 @@ reverse_proxy [<matcher>] [<upstreams...>] {
 ### Upstreams
 
 - **&lt;upstreams...&gt;** is a list of upstreams (backends) to which to proxy.
-- **to** is an alternate way to specify the list of upstreams, one (or more) per line.
+- **to** <span id="to"/> is an alternate way to specify the list of upstreams, one (or more) per line.
 
 Upstream addresses can take the form of a conventional [Caddy network address](/docs/conventions#network-addresses) or a URL that contains only scheme and host/port, with a special exception that the scheme may be prefixed by `srv+` to enable SRV DNS record lookups for load balancing. Valid examples:
 
@@ -111,7 +133,7 @@ When proxying over HTTPS, you may need to override the `Host` header (which by d
 
 Load balancing is used whenever more than one upstream is defined.
 
-- **lb_policy** is the name of the load balancing policy, along with any options. Default: `random`. Can be:
+- **lb_policy** <span id="lb_policy"/> is the name of the load balancing policy, along with any options. Default: `random`. Can be:
 	- `random` - randomly choose an upstream
 	- `random_choose <n>` - selects two or more upstreams randomly, then chooses one with least load (`n` is usually 2)
 	- `first` - choose first available upstream, from the order they are defined in the config
@@ -122,8 +144,8 @@ Load balancing is used whenever more than one upstream is defined.
 	- `header [field]` - map request header to sticky upstream
 	- `cookie [<name> [<secret>]]` - based on the given cookie (default name is `lb` if not specified), which value is hashed; optionally with a secret for HMAC-SHA256
 
-- **lb_try_duration** is a [duration value](/docs/conventions#durations) that defines how long to try selecting available backends for each request if the next available host is down. By default, this retry is disabled. Clients will wait for up to this long while the load balancer tries to find an available upstream host.
-- **lb_try_interval** is a [duration value](/docs/conventions#durations) that defines how long to wait between selecting the next host from the pool. Default is `250ms`. Only relevant when a request to an upstream host fails. Be aware that setting this to 0 with a non-zero `lb_try_duration` can cause the CPU to spin if all backends are down and latency is very low.
+- **lb_try_duration** <span id="lb_try_duration"/> is a [duration value](/docs/conventions#durations) that defines how long to try selecting available backends for each request if the next available host is down. By default, this retry is disabled. Clients will wait for up to this long while the load balancer tries to find an available upstream host.
+- **lb_try_interval** <span id="lb_try_interval"/> is a [duration value](/docs/conventions#durations) that defines how long to wait between selecting the next host from the pool. Default is `250ms`. Only relevant when a request to an upstream host fails. Be aware that setting this to 0 with a non-zero `lb_try_duration` can cause the CPU to spin if all backends are down and latency is very low.
 
 
 
@@ -131,13 +153,13 @@ Load balancing is used whenever more than one upstream is defined.
 
 Active health checks perform health checking in the background on a timer:
 
-- **health_uri** is the URI path (and optional query) for active health checks.
-- **health_port** is the port to use for active health checks, if different from the upstream's port.
-- **health_interval** is a [duration value](/docs/conventions#durations) that defines how often to perform active health checks.
-- **health_timeout** is a [duration value](/docs/conventions#durations) that defines how long to wait for a reply before marking the backend as down.
-- **health_status** is the HTTP status code to expect from a healthy backend. Can be a 3-digit status code, or a status code class ending in `xx`. For example: `200` (which is the default), or `2xx`.
-- **health_body** is a substring or regular expression to match on the response body of an active health check. If the backend does not return a matching body, it will be marked as down.
-- **health_headers** allows specifying headers to set on the active health check requests. This is useful if you need to change the `Host` header, or if you need to provide some authentication to your backend as part of your health checks.
+- **health_uri** <span id="health_uri"/> is the URI path (and optional query) for active health checks.
+- **health_port** <span id="health_port"/> is the port to use for active health checks, if different from the upstream's port.
+- **health_interval** <span id="health_interval"/> is a [duration value](/docs/conventions#durations) that defines how often to perform active health checks.
+- **health_timeout** <span id="health_timeout"/> is a [duration value](/docs/conventions#durations) that defines how long to wait for a reply before marking the backend as down.
+- **health_status** <span id="health_status"/> is the HTTP status code to expect from a healthy backend. Can be a 3-digit status code, or a status code class ending in `xx`. For example: `200` (which is the default), or `2xx`.
+- **health_body** <span id="health_body"/> is a substring or regular expression to match on the response body of an active health check. If the backend does not return a matching body, it will be marked as down.
+- **health_headers** <span id="health_headers"/> allows specifying headers to set on the active health check requests. This is useful if you need to change the `Host` header, or if you need to provide some authentication to your backend as part of your health checks.
 
 
 
@@ -145,11 +167,11 @@ Active health checks perform health checking in the background on a timer:
 
 Passive health checks happen inline with actual proxied requests:
 
-- **fail_duration**  is a [duration value](/docs/conventions#durations) that defines how long to remember a failed request. A duration > 0 enables passive health checking.
-- **max_fails** is the maximum number of failed requests within fail_timeout that are needed before considering a backend to be down; must be >= 1; default is 1.
-- **unhealthy_status** counts a request as failed if the response comes back with one of these status codes. Can be a 3-digit status code or a status code class ending in `xx`, for example: `404` or `5xx`.
-- **unhealthy_latency** is a [duration value](/docs/conventions#durations) that counts a request as failed if it takes this long to get a response.
-- **unhealthy_request_count** is the permissible number of simultaneous requests to a backend before marking it as down.
+- **fail_duration** <span id="fail_duration"/>  is a [duration value](/docs/conventions#durations) that defines how long to remember a failed request. A duration > 0 enables passive health checking.
+- **max_fails** <span id="max_fails"/> is the maximum number of failed requests within fail_timeout that are needed before considering a backend to be down; must be >= 1; default is 1.
+- **unhealthy_status** <span id="unhealthy_status"/> counts a request as failed if the response comes back with one of these status codes. Can be a 3-digit status code or a status code class ending in `xx`, for example: `404` or `5xx`.
+- **unhealthy_latency** <span id="unhealthy_latency"/> is a [duration value](/docs/conventions#durations) that counts a request as failed if it takes this long to get a response.
+- **unhealthy_request_count** <span id="unhealthy_request_count"/> is the permissible number of simultaneous requests to a backend before marking it as down.
 
 
 
@@ -157,10 +179,10 @@ Passive health checks happen inline with actual proxied requests:
 
 The proxy **buffers responses** by default for wire efficiency:
 
-- **flush_interval** is a [duration value](/docs/conventions#durations) that adjusts how often Caddy should flush the response buffer to the client. By default, no periodic flushing is done. A negative value disables response buffering, and flushes immediately after each write to the client. This option is ignored when the upstream's response is recognized as a streaming response, or if its content length is `-1`; for such responses, writes are flushed to the client immediately.
-- **buffer_requests** will cause the proxy to read the entire request body into a buffer before sending it upstream. This is very inefficient and should only be done if the upstream requires reading request bodies without delay (which is something the upstream application should fix).
-- **buffer_responses** will cause the entire response body to be read and buffered in memory before being proxied to the client. This should be avoided if at all possible for performance reasons, but could be useful if the backend has tighter memory constraints.
-- **max_buffer_size** if body buffering is enabled, this sets the maximum size of the buffers used for the requests and responses. This accepts all size formats supported by [go-humanize](https://github.com/dustin/go-humanize/blob/master/bytes.go).
+- **flush_interval** <span id="flush_interval"/> is a [duration value](/docs/conventions#durations) that adjusts how often Caddy should flush the response buffer to the client. By default, no periodic flushing is done. A negative value disables response buffering, and flushes immediately after each write to the client. This option is ignored when the upstream's response is recognized as a streaming response, or if its content length is `-1`; for such responses, writes are flushed to the client immediately.
+- **buffer_requests** <span id="buffer_requests"/> will cause the proxy to read the entire request body into a buffer before sending it upstream. This is very inefficient and should only be done if the upstream requires reading request bodies without delay (which is something the upstream application should fix).
+- **buffer_responses** <span id="buffer_responses"/> will cause the entire response body to be read and buffered in memory before being proxied to the client. This should be avoided if at all possible for performance reasons, but could be useful if the backend has tighter memory constraints.
+- **max_buffer_size** <span id="max_buffer_size"/> if body buffering is enabled, this sets the maximum size of the buffers used for the requests and responses. This accepts all size formats supported by [go-humanize](https://github.com/dustin/go-humanize/blob/master/bytes.go).
 
 
 
@@ -168,8 +190,8 @@ The proxy **buffers responses** by default for wire efficiency:
 
 The proxy can **manipulate headers** between itself and the backend:
 
-- **header_up** Sets, adds, removes, or performs a replacement in a request header going upstream to the backend.
-- **header_down** Sets, adds, removes, or performs a replacement in a response header coming downstream from the backend.
+- **header_up** <span id="header_up"/> Sets, adds, removes, or performs a replacement in a request header going upstream to the backend.
+- **header_down** <span id="header_down"/> Sets, adds, removes, or performs a replacement in a response header coming downstream from the backend.
 
 
 #### Defaults
@@ -198,7 +220,7 @@ reverse_proxy https://example.com {
 
 Caddy's proxy **transport** is pluggable:
 
-- **transport** defines how to communicate with the backend. Default is `http`.
+- **transport** <span id="transport"/> defines how to communicate with the backend. Default is `http`.
 
 
 #### The `http` transport
@@ -227,25 +249,25 @@ transport http {
 }
 ```
 
-- **read_buffer** is the size of the read buffer in bytes.
-- **write_buffer** is the size of the write buffer in bytes.
-- **max_response_header** is the maximum amount of bytes to read from response headers.
-- **dial_timeout** is how long to wait when connecting to the upstream socket. Accepts [duration values](/docs/conventions#durations).
-- **dial_fallback_delay** is how long to wait before spawning an RFC 6555 Fast Fallback connection. A negative value disables this. Accepts [duration values](/docs/conventions#durations).
-- **response_header_timeout** is how long to wait for reading response headers from the upstream. Accepts [duration values](/docs/conventions#durations).
-- **expect_continue_timeout** is how long to wait for the upstreams's first response headers after fully writing the request headers if the request has the header `Expect: 100-continue`. Accepts [duration values](/docs/conventions#durations).
-- **tls** uses HTTPS with the backend. This will be enabled automatically if you specify backends using the `https://` scheme or port `:443`.
-- **tls_client_auth** enables TLS client authentication one of two ways: (1) by specifying a domain name for which Caddy should obtain a certificate and keep it renewed, or (2) by specifying a certificate and key file to present for TLS client authentication with the backend.
-- **tls_insecure_skip_verify** turns off security. _Do not use in production._
-- **tls_timeout** is a [duration value](/docs/conventions#durations) that specifies how long to wait for the TLS handshake to complete.
-- **tls_trusted_ca_certs** is a list of PEM files that specify CA public keys to trust when connecting to the backend.
-- **tls_server_name** sets the ServerName (SNI) to put in the ClientHello; only needed if the remote server requires it.
-- **keepalive** is either `off` or a [duration value](/docs/conventions#durations) that specifies how long to keep connections open.
-- **keepalive_idle_conns** defines the maximum number of connections to keep alive.
-- **keepalive_idle_conns_per_host** if non-zero, controls the maximum idle (keep-alive) connections to keep per-host. Default: `32`
-- **versions** allows customizing which versions of HTTP to support. As a special case, "h2c" is a valid value which will enable cleartext HTTP/2 connections to the upstream (however, this is a non-standard feature that does not use Go's default HTTP transport, so it is exclusive of other features; subject to change or removal). Default: `1.1 2`, or if scheme is `h2c://`, `h2c 2`
-- **compression** can be used to disable compression to the backend by setting it to `off`.
-- **max_conns_per_host** optionally limits the total number of connections per host, including connections in the dialing, active, and idle states. Has no limit by default.
+- **read_buffer** <span id="read_buffer"/> is the size of the read buffer in bytes.
+- **write_buffer** <span id="write_buffer"/> is the size of the write buffer in bytes.
+- **max_response_header** <span id="max_response_header"/> is the maximum amount of bytes to read from response headers.
+- **dial_timeout** <span id="dial_timeout"/> is how long to wait when connecting to the upstream socket. Accepts [duration values](/docs/conventions#durations).
+- **dial_fallback_delay** <span id="dial_fallback_delay"/> is how long to wait before spawning an RFC 6555 Fast Fallback connection. A negative value disables this. Accepts [duration values](/docs/conventions#durations).
+- **response_header_timeout** <span id="response_header_timeout"/> is how long to wait for reading response headers from the upstream. Accepts [duration values](/docs/conventions#durations).
+- **expect_continue_timeout** <span id="expect_continue_timeout"/> is how long to wait for the upstreams's first response headers after fully writing the request headers if the request has the header `Expect: 100-continue`. Accepts [duration values](/docs/conventions#durations).
+- **tls** <span id="tls"/> uses HTTPS with the backend. This will be enabled automatically if you specify backends using the `https://` scheme or port `:443`.
+- **tls_client_auth** <span id="tls_client_auth"/> enables TLS client authentication one of two ways: (1) by specifying a domain name for which Caddy should obtain a certificate and keep it renewed, or (2) by specifying a certificate and key file to present for TLS client authentication with the backend.
+- **tls_insecure_skip_verify** <span id="tls_insecure_skip_verify"/> turns off security. _Do not use in production._
+- **tls_timeout** <span id="tls_timeout"/> is a [duration value](/docs/conventions#durations) that specifies how long to wait for the TLS handshake to complete.
+- **tls_trusted_ca_certs** <span id="tls_trusted_ca_certs"/> is a list of PEM files that specify CA public keys to trust when connecting to the backend.
+- **tls_server_name** <span id="tls_server_name"/> sets the ServerName (SNI) to put in the ClientHello; only needed if the remote server requires it.
+- **keepalive** <span id="keepalive"/> is either `off` or a [duration value](/docs/conventions#durations) that specifies how long to keep connections open.
+- **keepalive_idle_conns** <span id="keepalive_idle_conns"/> defines the maximum number of connections to keep alive.
+- **keepalive_idle_conns_per_host** <span id="keepalive_idle_conns_per_host"/> if non-zero, controls the maximum idle (keep-alive) connections to keep per-host. Default: `32`
+- **versions** <span id="versions"/> allows customizing which versions of HTTP to support. As a special case, "h2c" is a valid value which will enable cleartext HTTP/2 connections to the upstream (however, this is a non-standard feature that does not use Go's default HTTP transport, so it is exclusive of other features; subject to change or removal). Default: `1.1 2`, or if scheme is `h2c://`, `h2c 2`
+- **compression** <span id="compression"/> can be used to disable compression to the backend by setting it to `off`.
+- **max_conns_per_host** <span id="max_conns_per_host"/> optionally limits the total number of connections per host, including connections in the dialing, active, and idle states. Has no limit by default.
 
 
 
@@ -263,13 +285,13 @@ transport fastcgi {
 }
 ```
 
-- **root** is the root of the site. Default: `{http.vars.root}` or current working directory.
-- **split** is where to split the path to get PATH_INFO at the end of the URI.
-- **env** sets an extra environment variable to the given value. Can be specified more than once for multiple environment variables.
-- **resolve_root_symlink** enables resolving the `root` directory to its actual value by evaluating a symbolic link, if one exists.
-- **dial_timeout** is how long to wait when connecting to the upstream socket. Accepts [duration values](/docs/conventions#durations). Default: no timeout.
-- **read_timeout** is how long to wait when reading from the FastCGI server. Accepts [duration values](/docs/conventions#durations). Default: no timeout.
-- **write_timeout** is how long to wait when sending to the FastCGI server. Accepts [duration values](/docs/conventions#durations). Default: no timeout.
+- **root** <span id="root"/> is the root of the site. Default: `{http.vars.root}` or current working directory.
+- **split** <span id="split"/> is where to split the path to get PATH_INFO at the end of the URI.
+- **env** <span id="env"/> sets an extra environment variable to the given value. Can be specified more than once for multiple environment variables.
+- **resolve_root_symlink** <span id="resolve_root_symlink"/> enables resolving the `root` directory to its actual value by evaluating a symbolic link, if one exists.
+- **dial_timeout** <span id="dial_timeout"/> is how long to wait when connecting to the upstream socket. Accepts [duration values](/docs/conventions#durations). Default: no timeout.
+- **read_timeout** <span id="read_timeout"/> is how long to wait when reading from the FastCGI server. Accepts [duration values](/docs/conventions#durations). Default: no timeout.
+- **write_timeout** <span id="write_timeout"/> is how long to wait when sending to the FastCGI server. Accepts [duration values](/docs/conventions#durations). Default: no timeout.
 
 
 ### Intercepting responses
@@ -277,7 +299,7 @@ transport fastcgi {
 The reverse proxy can be configured to intercept responses from the backend. To facilitate this, response matchers can be defined (similar to the syntax for request matchers) and the first matching `handle_response` route will be invoked. When this happens, the response from the backend is not written to the client, and the configured `handle_response` route will be executed instead, and it is up to that route to write a response.
 
 - **@name** is the name of a [response matcher](#response-matcher). As long as each response matcher has a unique name, multiple matchers can be defined. A response can be matched on the status code and presence or value of a response header.
-- **handle_response** defines the route to execute when matched by the given matcher (or, if a matcher is omitted, all responses). The first matching block will be applied. Inside a `handle_response` block, any other [directives](/docs/caddyfile/directives) can be used.
+- **handle_response** <span id="handle_response"/> defines the route to execute when matched by the given matcher (or, if a matcher is omitted, all responses). The first matching block will be applied. Inside a `handle_response` block, any other [directives](/docs/caddyfile/directives) can be used.
 
 Three placeholders will be made available to the `handle_response` routes:
 

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -2,6 +2,13 @@
 title: tls (Caddyfile directive)
 ---
 
+<script>
+$(function() {
+	// We'll add links to all the subdirectives if a matching anchor tag is found on the page.
+	addLinksToSubdirectives();
+});
+</script>
+
 # tls
 
 Configures TLS for the site.
@@ -41,8 +48,8 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 - **internal** means to use Caddy's internal, locally-trusted CA to produce certificates for this site.
 - **&lt;email&gt;** is the email address to use for the ACME account managing the site's certificates.
 - **&lt;cert_file&gt;** and **&lt;key_file&gt;** are the paths to the certificate and private key PEM files. Specifying just one is invalid.
-- **protocols** specifies the minimum and maximum protocol versions. Default min: `tls1.2`. Default max: `tls1.3`
-- **ciphers** specifies the list of cipher suite names in descending preference order. It is recommended to not change these unless you know what you're doing. Note that cipher suites are not customizable for TLS 1.3; and not all TLS 1.2 ciphers are enabled by default. The supported names are (in no particular order here):
+- **protocols** <span id="protocols"/> specifies the minimum and maximum protocol versions. Default min: `tls1.2`. Default max: `tls1.3`
+- **ciphers** <span id="ciphers"/> specifies the list of cipher suite names in descending preference order. It is recommended to not change these unless you know what you're doing. Note that cipher suites are not customizable for TLS 1.3; and not all TLS 1.2 ciphers are enabled by default. The supported names are (in no particular order here):
 	- TLS_RSA_WITH_3DES_EDE_CBC_SHA
 	- TLS_RSA_WITH_AES_128_CBC_SHA
 	- TLS_RSA_WITH_AES_256_CBC_SHA
@@ -62,22 +69,22 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 	- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 	- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 	- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-- **curves** specifies the list of EC curves to support. It is recommended to not change these. Supported values are:
+- **curves** <span id="curves"/> specifies the list of EC curves to support. It is recommended to not change these. Supported values are:
 	- x25519
 	- secp256r1
 	- secp384r1
 	- secp521r1
-- **alpn** is the list of values to advertise in the ALPN extension of the TLS handshake.
-- **load** specifies a list of folders from which to load PEM files that are certificate+key bundles.
-- **ca** changes the ACME CA endpoint. This is most often used to set [Let's Encrypt's staging endpoint](https://letsencrypt.org/docs/staging-environment/) when testing, or an internal ACME server. (To change this value for the whole Caddyfile, use the `acme_ca` [global option](/docs/caddyfile/options) instead.)
-- **ca_root** specifies a PEM file that contains a trusted root certificate for the ACME CA endpoint, if not in the system trust store.
-- **key_type** is the type of key to use when generating CSRs. Only set this if you have a specific requirement.
-- **dns** enables the [DNS challenge](/docs/automatic-https#dns-challenge) using the specified provider plugin, which must be plugged in from one of the [caddy-dns](https://github.com/caddy-dns) repositories. Each provider plugin may have their own syntax following their name; refer to their docs for details. Maintaining support for each DNS provider is a community effort. [Learn how to enable the DNS challenge for your provider at our wiki.](https://caddy.community/t/how-to-use-dns-provider-modules-in-caddy-2/8148)
-- **resolvers** customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones. If set here, the resolvers will propagate to all configured certificate issuers.
-- **eab** configures ACME external account binding (EAB) for this site, using the key ID and MAC key provided by your CA.
-- **on_demand** enables [on-demand TLS](/docs/automatic-https#on-demand-tls) for the hostnames given in the site block's address(es). **Security warning:** Doing so in production is insecure unless you also configure the [`on_demand_tls` global option](https://caddyserver.com/docs/caddyfile/options#on-demand-tls) to mitigate abuse.
-- **client_auth** enables and configures TLS client authentication:
-	- **mode** is the mode for authenticating the client. Allowed values are:
+- **alpn** <span id="alpn"/> is the list of values to advertise in the ALPN extension of the TLS handshake.
+- **load** <span id="load"/> specifies a list of folders from which to load PEM files that are certificate+key bundles.
+- **ca** <span id="ca"/> changes the ACME CA endpoint. This is most often used to set [Let's Encrypt's staging endpoint](https://letsencrypt.org/docs/staging-environment/) when testing, or an internal ACME server. (To change this value for the whole Caddyfile, use the `acme_ca` [global option](/docs/caddyfile/options) instead.)
+- **ca_root** <span id="ca_root"/> specifies a PEM file that contains a trusted root certificate for the ACME CA endpoint, if not in the system trust store.
+- **key_type** <span id="key_type"/> is the type of key to use when generating CSRs. Only set this if you have a specific requirement.
+- **dns** <span id="dns"/> enables the [DNS challenge](/docs/automatic-https#dns-challenge) using the specified provider plugin, which must be plugged in from one of the [caddy-dns](https://github.com/caddy-dns) repositories. Each provider plugin may have their own syntax following their name; refer to their docs for details. Maintaining support for each DNS provider is a community effort. [Learn how to enable the DNS challenge for your provider at our wiki.](https://caddy.community/t/how-to-use-dns-provider-modules-in-caddy-2/8148)
+- **resolvers** <span id="resolvers"/> customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones. If set here, the resolvers will propagate to all configured certificate issuers.
+- **eab** <span id="eab"/> configures ACME external account binding (EAB) for this site, using the key ID and MAC key provided by your CA.
+- **on_demand** <span id="on_demand"/> enables [on-demand TLS](/docs/automatic-https#on-demand-tls) for the hostnames given in the site block's address(es). **Security warning:** Doing so in production is insecure unless you also configure the [`on_demand_tls` global option](https://caddyserver.com/docs/caddyfile/options#on-demand-tls) to mitigate abuse.
+- **client_auth** <span id="client_auth"/> enables and configures TLS client authentication:
+	- **mode** <span id="mode"/> is the mode for authenticating the client. Allowed values are:
 
 		| Mode               | Description                                                                              |
 		|--------------------|------------------------------------------------------------------------------------------|
@@ -88,14 +95,14 @@ tls [internal|<email>] | [<cert_file> <key_file>] {
 
 	Default: `require_and_verify` if any `trusted_ca_cert` or `trusted_leaf_cert` are provided; otherwise, `require`.
 	
-	- **trusted_ca_cert** is a base64 DER-encoded CA certificate against which to validate client certificates.
-	- **trusted_ca_cert_file** is a path to a PEM CA certificate file against which to validate client certificates.
-	- **trusted_leaf_cert** is a base64 DER-encoded client leaf certificate to accept.
-	- **trusted_leaf_cert_file** is a path to a PEM CA certificate file against which to validate client certificates.
+	- **trusted_ca_cert** <span id="trusted_ca_cert"/> is a base64 DER-encoded CA certificate against which to validate client certificates.
+	- **trusted_ca_cert_file** <span id="trusted_ca_cert_file"/> is a path to a PEM CA certificate file against which to validate client certificates.
+	- **trusted_leaf_cert** <span id="trusted_leaf_cert"/> is a base64 DER-encoded client leaf certificate to accept.
+	- **trusted_leaf_cert_file** <span id="trusted_leaf_cert_file"/> is a path to a PEM CA certificate file against which to validate client certificates.
 
 	Multiple `trusted_*` directives may be used to specify multiple CA or leaf certificates. Client certificates which are not listed as one of the leaf certificates or signed by any of the specified CAs will be rejected according to the **mode**.
 
-- **issuer** configures a custom certificate issuer, or a source from which to obtain certificates. Which issuer is used and the options that follow in this segment depend on the issuer modules that are available (see below for the standard issuers; plugins may add others). Some of the other subdirectives such as `ca` and `dns` are actually shortcuts for configuring the `acme` issuer (and this subdirective was added later), so specifying this directive and some of the others is confusing and thus prohibited. This subdirective can be specified multiple times to configure multiple, redundant issuers; if one fails to issue a cert, the next one will be tried.
+- **issuer** <span id="issuer"/> configures a custom certificate issuer, or a source from which to obtain certificates. Which issuer is used and the options that follow in this segment depend on the issuer modules that are available (see below for the standard issuers; plugins may add others). Some of the other subdirectives such as `ca` and `dns` are actually shortcuts for configuring the `acme` issuer (and this subdirective was added later), so specifying this directive and some of the others is confusing and thus prohibited. This subdirective can be specified multiple times to configure multiple, redundant issuers; if one fails to issue a cert, the next one will be tried.
 
 ### Issuers
 
@@ -127,23 +134,23 @@ Obtains certificates using the ACME protocol.
 }
 ```
 
-- **dir** is the URL to the ACME CA's directory. Default: `https://acme-v02.api.letsencrypt.org/directory`
-- **test_dir** is an optional fallback directory to use when retrying challenges; if all challenges fail, this endpoint will be used during retries; useful if a CA has a staging endpoint where you want to avoid rate limits on their production endpoint. Default: `https://acme-staging-v02.api.letsencrypt.org/directory`
-- **email** is the ACME account contact email address.
-- **timeout** is a [duration value](/docs/conventions#durations) that sets how long to wait before timing out an ACME operation.
-- **disable_http_challenge** will disable the HTTP challenge.
-- **disable_tlsalpn_challenge** will disable the TLS-ALPN challenge.
-- **alt_http_port** is an alternate port on which to serve the HTTP challenge; it has to happen on port 80 so you must forward packets to this alternate port.
-- **alt_tlsalpn_port** is an alternate port on which to serve the TLS-ALPN challenge; it has to happen on port 443 so you must forward packets to this alternate port.
-- **eab** specifies an External Account Binding which may be required with some ACME CAs.
-- **trusted_roots** is one or more root certificates (as PEM filenames) to trust when connecting to the ACME CA server.
-- **dns** configures the DNS challenge.
-- **propagation_timeout** is a [duration value](/docs/conventions#durations) that sets how long to wait for DNS TXT records to propagate when using the DNS challenge. Default 2 minutes.
-- **resolvers** customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones.
-- **preferred_chains** specifies which certificate chains Caddy should prefer; useful if your CA provides multiple chains. Use one of the following options:
-	- **smallest** will tell Caddy to prefer chains with the fewest amount of bytes.
-	- **root_common_name** is a list of one or more common names; Caddy will choose the first chain that has a root that matches with at least one of the specified common names.
-	- **any_common_name** is a list of one or more common names; Caddy will choose the first chain that has an issuer that matches with at least one of the specified common names.
+- **dir** <span id="dir"/> is the URL to the ACME CA's directory. Default: `https://acme-v02.api.letsencrypt.org/directory`
+- **test_dir** <span id="test_dir"/> is an optional fallback directory to use when retrying challenges; if all challenges fail, this endpoint will be used during retries; useful if a CA has a staging endpoint where you want to avoid rate limits on their production endpoint. Default: `https://acme-staging-v02.api.letsencrypt.org/directory`
+- **email** <span id="email"/> is the ACME account contact email address.
+- **timeout** <span id="timeout"/> is a [duration value](/docs/conventions#durations) that sets how long to wait before timing out an ACME operation.
+- **disable_http_challenge** <span id="disable_http_challenge"/> will disable the HTTP challenge.
+- **disable_tlsalpn_challenge** <span id="disable_tlsalpn_challenge"/> will disable the TLS-ALPN challenge.
+- **alt_http_port** <span id="alt_http_port"/> is an alternate port on which to serve the HTTP challenge; it has to happen on port 80 so you must forward packets to this alternate port.
+- **alt_tlsalpn_port** <span id="alt_tlsalpn_port"/> is an alternate port on which to serve the TLS-ALPN challenge; it has to happen on port 443 so you must forward packets to this alternate port.
+- **eab** <span id="eab"/> specifies an External Account Binding which may be required with some ACME CAs.
+- **trusted_roots** <span id="trusted_roots"/> is one or more root certificates (as PEM filenames) to trust when connecting to the ACME CA server.
+- **dns** <span id="dns"/> configures the DNS challenge.
+- **propagation_timeout** <span id="propagation_timeout"/> is a [duration value](/docs/conventions#durations) that sets how long to wait for DNS TXT records to propagate when using the DNS challenge. Default 2 minutes.
+- **resolvers** <span id="resolvers"/> customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones.
+- **preferred_chains** <span id="preferred_chains"/> specifies which certificate chains Caddy should prefer; useful if your CA provides multiple chains. Use one of the following options:
+	- **smallest** <span id="smallest"/> will tell Caddy to prefer chains with the fewest amount of bytes.
+	- **root_common_name** <span id="root_common_name"/> is a list of one or more common names; Caddy will choose the first chain that has a root that matches with at least one of the specified common names.
+	- **any_common_name** <span id="any_common_name"/> is a list of one or more common names; Caddy will choose the first chain that has an issuer that matches with at least one of the specified common names.
 
 
 #### zerossl

--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -2,6 +2,31 @@
 title: Request matchers (Caddyfile)
 ---
 
+<script>
+$(function() {
+	// We'll add links on the matchers in the code blocks
+	// to their associated anchor tags.
+	let headers = $('article h3').map((i, el) => el.id.replace(/-/g, "_")).toArray();
+	$('pre.chroma .k')
+		.filter((k, item) => headers.includes(item.innerText))
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			let url = '#' + item.innerText.replace(/_/g, "-");
+			$(item).html('<a href="' + url + '" style="color: inherit;" title="' + text + '">' + text + '</a>');
+		});
+
+	// Link matcher tokens based on their contents to the syntax section
+	$('pre.chroma .nd')
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			let anchor = "named-matchers"
+			if (text == "*") anchor = "wildcard-matchers"
+			if (text.startsWith('/')) anchor = "path-matchers"
+			$(item).html('<a href="#' + anchor + '" style="color: inherit;" title="Matcher token">' + text + '</a>');
+		});
+});
+</script>
+
 # Request Matchers
 
 **Request matchers** can be used to filter (or classify) requests by specific criteria.

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -2,6 +2,26 @@
 title: Global options (Caddyfile)
 ---
 
+<script>
+$(function() {
+	// We'll add links on the options in the code block at the top
+	// to their associated anchor tags.
+	let headers = $('article h5').map((i, el) => el.id.replace(/-/g, "_")).toArray();
+	$('pre.chroma .k')
+		.filter((k, item) => headers.includes(item.innerText))
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			let url = '#' + item.innerText.replace(/_/g, "-");
+			$(item).html('<a href="' + url + '" style="color: inherit;" title="' + text + '">' + text + '</a>');
+		});
+	$('pre.chroma .k:contains("servers")')
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			$(item).html('<a href="#server-options" style="color: inherit;" title="Server Options">' + text + '</a>');
+		});
+});
+</script>
+
 # Global options
 
 The Caddyfile has a way for you to specify options that apply globally. Some options act as default values, while others customize the behavior of the Caddyfile [adapter](/docs/config-adapters).

--- a/src/resources/js/docs.js
+++ b/src/resources/js/docs.js
@@ -34,19 +34,17 @@ $(function() {
 	// Add links to Caddyfile directive tokens in code blocks.
 	// See include/docs-head.html for the whitelist bootstrapping logic
 	$('pre.chroma .k')
-		.filter(function (k, item) {
-			return window.CaddyfileDirectives.includes(item.innerText)
-				|| item.innerText === '<directives...>';
-		})
+		.filter((k, item) =>
+			window.CaddyfileDirectives.includes(item.innerText)
+				|| item.innerText === '<directives...>'
+		)
 		.map(function(k, item) {
 			let text = item.innerText;
 			let url = text === '<directives...>'
 				? '/docs/caddyfile/directives'
 				: '/docs/caddyfile/directives/' + text;
-			$(item)
-				.html('<a href="' + url + '" style="color: inherit;" title="Directive"></a>')
-				.find('a')
-				.text(text);
+			text = text.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			$(item).html('<a href="' + url + '" style="color: inherit;" title="Directive">' + text + '</a>');
 		});
 
 	// Add links to [<matcher>] or named matcher tokens in code blocks.
@@ -54,32 +52,25 @@ $(function() {
 	// so we must use text() to change the link text.
 	$('pre.chroma .nd')
 		.map(function(k, item) {
-			let text = item.innerText;
-			$(item)
-				.html('<a href="/docs/caddyfile/matchers" style="color: inherit;" title="Matcher token"></a>')
-				.find('a')
-				.text(text);
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			$(item).html('<a href="/docs/caddyfile/matchers#syntax" style="color: inherit;" title="Matcher token">' + text + '</a>');
 		});
-
-	// On the global options page only, we'll add links to the options to the anchor tags
-	if (window.location.pathname === '/docs/caddyfile/options') {
-		let headers = $('article h5').map(function (i, el) {
-			return el.id.replace(/-/g, "_");
-		}).toArray();
-		$('pre.chroma .k')
-			.filter(function (k, item) {
-				return headers.includes(item.innerText);
-			})
-			.map(function(k, item) {
-				let text = item.innerText;
-				let url = '#' + item.innerText.replace(/_/g, "-");
-				$(item)
-					.html('<a href="' + url + '" style="color: inherit;" title="Global option"></a>')
-					.find('a')
-					.text(text);
-			});
-	}
 });
+
+// addLinkaddLinksToSubdirectivessToAnchors finds all the ID anchors
+// in the article, and turns any directive or subdirective span into
+// links that have an ID on the page. This is opt-in for each page,
+// because it's not necessary to run everywhere.
+function addLinksToSubdirectives() {
+	let anchors = $('article *[id]').map((i, el) => el.id).toArray();
+	$('pre.chroma .k')
+		.filter((k, item) => anchors.includes(item.innerText))
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			let url = '#' + item.innerText;
+			$(item).html('<a href="' + url + '" style="color: inherit;" title="' + text + '">' + text + '</a>');
+		});
+}
 
 function stripScheme(url) {
 	return url.substring(url.indexOf("://")+3);


### PR DESCRIPTION
This makes navigating some of the bigger Caddyfile pages much nicer. This is a somewhat more generalized solution to adding links to subdirectives throughout the pages.

I only turned this on for the longer pages, because it's less beneficial for shorter pages since the subdirectives fit on the same screen at code blocks.

Essentially how it works is I added `<span id="subdirective"/>` anchors beside each bullet item for subdirectives to make an invisible anchor point that we can jump to. Then, on page load, I use `$('article *[id]')` to get all of the IDs on elements within the article body (includes any `h2` headers and such), which acts as an allow-list. Then I grab all the `$('pre.chroma .k')` elements which are the directive or subdirectives as per our syntax highlighting. Then it linkifies them if they have an ID on the page that matches.

I moved the script for the `options` page to a script block in the `.md` itself since it was kinda weird to have page-specific code in `docs.js`, we'd need to check the current request path which wasn't ideal.

I also added a bit of edgecase magic for other pages, like `matchers.md` fix up some links to be more useful, like linking inline matcher tokens to their respective type, and matchers to their respective `h3` header.