### PR TITLE
docs: Mention compression header behaviour in `reverse_proxy`

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -201,6 +201,7 @@ By default, Caddy passes thru incoming headers to the backend&mdash;including th
 - It adds or augments the [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) header field.
 - It sets the [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) header field.
 
+Additionally, Caddy will also set `Accept-Encoding: gzip` if that header is missing in the request from the client. This behavior can be disabled by setting `compression off` in the `http` transport.
 
 #### HTTPS
 

--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -201,7 +201,7 @@ By default, Caddy passes thru incoming headers to the backend&mdash;including th
 - It adds or augments the [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) header field.
 - It sets the [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) header field.
 
-Additionally, Caddy will also set `Accept-Encoding: gzip` if that header is missing in the request from the client. This behavior can be disabled by setting `compression off` in the `http` transport.
+Additionally, when using the [`http` transport](#the-http-transport), the `Accept-Encoding: gzip` header will be set, if it is missing in the request from the client. This behavior can be disabled with [`compression off`](#compression) on the transport.
 
 #### HTTPS
 


### PR DESCRIPTION
Documantion says: "By default, Caddy passes thru incoming headers [...], with two exceptions:". But technically there is another another header that is added (if not present): `Accept-Encoding`. 

When the client is a web browser this header should be already set. But for curl or similar tools, that might not be the case.