### PR TITLE
reverse_proxy: document how to strip a path prefix

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -375,6 +375,15 @@ reverse_proxy https://example.com {
 ```
 
 
+Strip a path prefix before proxying:
+
+```caddy-d
+handle_path /prefix/* {
+	reverse_proxy localhost:9000
+}
+```
+
+
 Replace a path prefix before proxying:
 
 ```caddy-d


### PR DESCRIPTION
Documentation for https://github.com/caddyserver/caddy/issues/4512