### PR TITLE
docs: Fix Debian installation instructions

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -45,16 +45,24 @@ Installing this package automatically starts and runs Caddy as a [systemd servic
 Stable releases:
 
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \\</span>
+<span class="bash-continuation">  | gpg --dearmor \\</span>
+<span class="bash-continuation">  | sudo tee /usr/share/keyrings/caddy-stable-archive-keyring.gpg >/dev/null</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \\</span>
+<span class="bash-continuation">  | sed 's|^deb\(-src\)\?|\0 [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg]|' \\</span>
+<span class="bash-continuation">  | sudo tee /etc/apt/sources.list.d/caddy-stable.list</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 
 Testing releases (includes betas and release candidates):
 
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-testing.asc</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-testing.list</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' \\</span>
+<span class="bash-continuation">  | gpg --dearmor \\</span>
+<span class="bash-continuation">  | sudo tee /usr/share/keyrings/caddy-testing-archive-keyring.gpg >/dev/null</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' \\</span>
+<span class="bash-continuation">  | sed 's|^deb\(-src\)\?|\0 [signed-by=/usr/share/keyrings/caddy-testing-archive-keyring.gpg]|' \\</span>
+<span class="bash-continuation">  | sudo tee /etc/apt/sources.list.d/caddy-testing.list</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 

--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -45,24 +45,16 @@ Installing this package automatically starts and runs Caddy as a [systemd servic
 Stable releases:
 
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \\</span>
-<span class="bash-continuation">  | gpg --dearmor \\</span>
-<span class="bash-continuation">  | sudo tee /usr/share/keyrings/caddy-stable-archive-keyring.gpg >/dev/null</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \\</span>
-<span class="bash-continuation">  | sed 's|^deb\(-src\)\?|\0 [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg]|' \\</span>
-<span class="bash-continuation">  | sudo tee /etc/apt/sources.list.d/caddy-stable.list</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 
 Testing releases (includes betas and release candidates):
 
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' \\</span>
-<span class="bash-continuation">  | gpg --dearmor \\</span>
-<span class="bash-continuation">  | sudo tee /usr/share/keyrings/caddy-testing-archive-keyring.gpg >/dev/null</span>
-<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' \\</span>
-<span class="bash-continuation">  | sed 's|^deb\(-src\)\?|\0 [signed-by=/usr/share/keyrings/caddy-testing-archive-keyring.gpg]|' \\</span>
-<span class="bash-continuation">  | sudo tee /etc/apt/sources.list.d/caddy-testing.list</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-testing-archive-keyring.gpg</span>
+<span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-testing.list</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 

--- a/src/resources/css/docs.css
+++ b/src/resources/css/docs.css
@@ -386,13 +386,21 @@ pre > code.cmd {
 }
 
 code.cmd.bash,
-code.cmd .bash {
+code.cmd .bash,
+code.cmd.bash-continuation,
+code.cmd .bash-continuation {
 	font-weight: bold;
 }
 
 code.cmd.bash::before,
 code.cmd .bash::before {
-    content: '$';
+	content: '$';
+	margin-right: .5rem;
+}
+
+code.cmd.bash-continuation::before,
+code.cmd .bash-continuation::before {
+	content: '>';
 	margin-right: .5rem;
 }
 


### PR DESCRIPTION
Adding GPG keys to `/etc/apt/trusted.gpg` or `/etc/apt/trusted.gpg.d/` is highly discouraged (this includes usage of `apt-key add`), because these keys are trusted to sign package metadata from **all** sources.
Some references:
- [Debian Wiki article](https://wiki.debian.org/DebianRepository/UseThirdParty) with basic instructions.
- [Cloudflare Blog article](https://blog.cloudflare.com/dont-use-apt-key/) for an in-depth description of the issue.

While it doesn't make the installation instructions any more pretty, this is actually the right way to do it.

Another improvement would be to not download the list file but hardcode the URLs. This would remove that ugly sed call as well.
```sh
curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
  | gpg --dearmor \
  | sudo tee /usr/share/keyrings/caddy-stable-archive-keyring.gpg >/dev/null
cat - | sudo tee /etc/apt/sources.list.d/caddy-stable.list <<EOS
# Source: Caddy
# Site: https://github.com/caddyserver/caddy
# Repository: Caddy / stable
# Description: Fast, multi-platform web server with automatic HTTPS

deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
deb-src [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
EOS
```