### PR TITLE
logos: In dark mode, use invert + hue-rotate

### DIFF
--- a/src/resources/css/docs.css
+++ b/src/resources/css/docs.css
@@ -935,8 +935,13 @@ td code {
 	}
 
 	#logo {
-		/* TODO: Add some color */
-		filter: invert(1) opacity(.35);
+		filter: invert(1);
+	}
+	#zerossl-logo {
+		filter: invert(1) hue-rotate(180deg);
+	}
+	#footer-logo {
+		filter: invert(1) hue-rotate(180deg);
 	}
 
 	#logo-docs {


### PR DESCRIPTION
The ZeroSSL logo and the bottom Caddy logo didn't look good in dark mode.

The lock logo at the bottom now looks slightly funky but I think it kinda works 😂 

The clever thing here is we invert the colors, but inverting also inverts the colored parts, not only the greyscale; so then you can hue-rotate to un-invert the non-grayscale parts. Pretty neat trick.

---

Before:

![image](https://user-images.githubusercontent.com/2111701/167774540-0da125d1-51b1-489e-af29-e99fcd854431.png)

![image](https://user-images.githubusercontent.com/2111701/167774560-30abd55f-69a8-42c4-b961-72a6169eab9e.png)


After:

![image](https://user-images.githubusercontent.com/2111701/167774594-05589da9-7deb-4335-a994-55a9264621e4.png)

![image](https://user-images.githubusercontent.com/2111701/167774605-d0355796-9dc2-421e-ac12-73b5dab7f22c.png)
