### PR TITLE
json: Make URL #fragment jump to the right spot after loading

### DIFF
--- a/src/resources/js/json-docs.js
+++ b/src/resources/js/json-docs.js
@@ -22,6 +22,12 @@ $.get("/api/docs/config"+configPath, function(json) {
 			$('<span> &rsaquo; <a href="'+jsonDocsPathPrefix+bcPath.substr(1)+'/" class="breadcrumb has-popup" data-sibling-path="'+bcSiblingPath+'">'+pathComponents[i]+'</a></span>').appendTo($bc);
 		}
 
+		// re-trigger the URL fragment if any, to scroll to the archor
+		var fragment = window.location.hash;
+		if (fragment) {
+			window.location.hash = '';
+			window.location.hash = fragment;
+		}
 	});
 });
 


### PR DESCRIPTION
I think this is a big usability fix. Click on https://caddyserver.com/docs/json/apps/http/#servers/tls_connection_policies/client_authentication for example; you'd expect this would scroll the browser down to that specific config option, but it doesn't, it just scrolls down _a bit_ at page load, then since the content is loaded async with JS, it doesn't go to the right spot.

We can actually just reset the `window.location.hash` real quick right after the content loads, and that'll trigger the browser scrolling to the right spot. Super nice!

This way, we can actually link to specific spots in the JSON docs and it'll actually bring the user there.