### PR TITLE
docs: Changes for v2.5.2 release

### DIFF
--- a/src/docs/markdown/api.md
+++ b/src/docs/markdown/api.md
@@ -278,15 +278,14 @@ Returns the current status of the configured reverse proxy upstreams (backends) 
 
 <pre><code class="cmd"><span class="bash">curl "http://localhost:2019/reverse_proxy/upstreams" | jq</span>
 [
-	{"address": "10.0.1.1:80", "healthy": true, "num_requests": 4, "fails": 2},
-	{"address": "10.0.1.2:80", "healthy": true, "num_requests": 5, "fails": 4},
-	{"address": "10.0.1.3:80", "healthy": true, "num_requests": 3, "fails": 3}
+	{"address": "10.0.1.1:80", "num_requests": 4, "fails": 2},
+	{"address": "10.0.1.2:80", "num_requests": 5, "fails": 4},
+	{"address": "10.0.1.3:80", "num_requests": 3, "fails": 3}
 ]</code></pre>
 
 Each entry in the JSON array is a configured [upstream](/docs/json/apps/http/servers/routes/handle/reverse_proxy/upstreams/) stored in the global upstream pool.
 
 - **address** is the dial address of the upstream. For SRV upstreams, this is the `lookup_srv` DNS name.
-- **healthy** reflects whether Caddy believes the upstream to be healthy or not. Note that "health" is a distinct concept from "availability". An unhealthy backend will always be unavailable, but a healthy backend might not be available. Health is a global characteristic regardless of specific reverse proxy handler configuration, whereas availability is determined by the configuration of the specific reverse proxy handler. For example, a healthy backend would be unavailable if the handler is configured to only allow N requests at a time and it currently has N active requests. The "healthy" property does not reflect availability.
 - **num_requests** is the amount of active requests currently being handled by the upstream.
 - **fails** the current number of failed requests remembered, as configured by passive health checks.
 

--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -258,6 +258,7 @@ You can use any [Caddy placeholders](/docs/conventions#placeholders) in the Cadd
 | `{upstream_hostport}` | `{http.reverse_proxy.upstream.hostport}` |
 | `{rp.*}` | `{http.reverse_proxy.*}` |
 | `{vars.*}` | `{http.vars.*}` |
+| `{err.*}` | `{http.error.*}` |
 
 
 

--- a/src/docs/markdown/caddyfile/directives/error.md
+++ b/src/docs/markdown/caddyfile/directives/error.md
@@ -37,7 +37,7 @@ example.com {
 
     # Handle the error by serving an HTML page 
     handle_errors {
-        rewrite * /{http.error.status_code}.html
+        rewrite * /{err.status_code}.html
 		file_server
     }
 

--- a/src/docs/markdown/caddyfile/directives/handle_errors.md
+++ b/src/docs/markdown/caddyfile/directives/handle_errors.md
@@ -33,7 +33,7 @@ Custom error pages based on the status code (i.e. a page called `404.html` for 4
 
 ```caddy-d
 handle_errors {
-	rewrite * /{http.error.status_code}.html
+	rewrite * /{err.status_code}.html
 	file_server
 }
 ```
@@ -52,7 +52,7 @@ Reverse proxy to a professional server that is highly qualified for handling HTT
 
 ```caddy-d
 handle_errors {
-	rewrite * /{http.error.status_code}
+	rewrite * /{err.status_code}
 	reverse_proxy https://http.cat {
 		header_up Host http.cat
 	}
@@ -63,7 +63,7 @@ Simply use [`respond`](/docs/caddyfile/directives/respond) to return the error c
 
 ```caddy-d
 handle_errors {
-	respond "{http.error.status_code} {http.error.status_text}"
+	respond "{err.status_code} {err.status_text}"
 }
 ```
 
@@ -71,7 +71,7 @@ To handle specific error codes differently, use an [`expression`](/docs/caddyfil
 
 ```caddy-d
 handle_errors {
-	@4xx expression `{http.error.status_code} >= 400 && {http.error.status_code} < 500`
+	@4xx expression `{err.status_code} >= 400 && {err.status_code} < 500`
 	respond @4xx "It's a 4xx error!"
 
 	respond "It's not a 4xx error."

--- a/src/docs/markdown/caddyfile/directives/header.md
+++ b/src/docs/markdown/caddyfile/directives/header.md
@@ -12,20 +12,37 @@ By default, header operations are performed immediately unless any of the header
 ## Syntax
 
 ```caddy-d
-header [<matcher>] [[+|-|?]<field> [<value>|<find>|<default_value>] [<replace>]] {
+header [<matcher>] [[+|-|?]<field> [<value>|<find>] [<replace>]] {
+	# Replace
 	<field> <find> <replace>
+
+	# Add or Set
 	[+]<field> <value>
+
+	# Delete
 	-<field>
-	?<field> <default_value>
+
+	# Default
+	?<field> <value>
+
 	[defer]
 }
 ```
 
-- **&lt;field&gt;** is the name of the header field. By default, will overwrite any existing field of the same name. Prefix with `+` to add the field instead of replace, or prefix with `-` to remove the field.
+- **&lt;field&gt;** is the name of the header field. By default, will overwrite any existing field of the same name.
+
+  Prefix with `+` to add the field instead of overwriting (setting) the field if it already exists; header fields can appear more than once in a request.
+
+  Prefix with `-` to delete the field. The field may use prefix or suffix `*` wildcards to delete all matching fields.
+
+  Prefix with `?` to set a default value for the field. The field is only written if it doesn't yet exist.
+
 - **&lt;value&gt;** is the header field value, if adding or setting a field.
-- **&lt;default_value&gt;** is the header field value that will be set only if the header does not already exist.
+
 - **&lt;find&gt;** is the substring or regular expression to search for.
+
 - **&lt;replace&gt;** is the replacement value; required if performing a search-and-replace.
+
 - **defer** will force the header operations to be deferred until the response is being written out to the client. This is automatically enabled if any of the header fields are being deleted with `-`, or when setting a default value with `?`.
 
 For multiple header manipulations, you can open a block and specify one manipulation per line in the same way.

--- a/src/docs/markdown/caddyfile/directives/request_header.md
+++ b/src/docs/markdown/caddyfile/directives/request_header.md
@@ -13,9 +13,16 @@ Manipulates HTTP header fields on the request. It can set, add, and delete heade
 request_header [<matcher>] [[+|-]<field> [<value>|<find>] [<replace>]]
 ```
 
-- **&lt;field&gt;** is the name of the header field. By default, will overwrite any existing field of the same name. Prefix with `+` to add the field instead of replace, or prefix with `-` to remove the field.
+- **&lt;field&gt;** is the name of the header field. By default, will overwrite any existing field of the same name.
+
+  Prefix with `+` to add the field instead of overwriting (setting) the field if it already exists; header fields can appear more than once in a request.
+
+  Prefix with `-` to delete the field. The field may use prefix or suffix `*` wildcards to delete all matching fields.
+
 - **&lt;value&gt;** is the header field value, if adding or setting a field.
+
 - **&lt;find&gt;** is the substring or regular expression to search for.
+
 - **&lt;replace&gt;** is the replacement value; required if performing a search-and-replace.
 
 
@@ -25,4 +32,10 @@ Remove the Referer header from the request:
 
 ```caddy-d
 request_header -Referer
+```
+
+Delete all headers containing an underscore from the request:
+
+```caddy-d
+request_header -*_*
 ```

--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -201,7 +201,7 @@ expression {method}.startsWith("P")
 Match requests where handler returned error status code `404`, would be used in conjunction with the [`handle_errors` directive](/docs/caddyfile/directives/handle_errors):
 
 ```caddy-d
-expression {http.error.status_code} == 404
+expression {err.status_code} == 404
 ```
 
 

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -49,7 +49,7 @@ Possible options are:
 	debug
 	http_port    <port>
 	https_port   <port>
-	default_bind <host>
+	default_bind <hosts...>
 	order <dir1> first|last|[before|after <dir2>]
 	storage <module_name> {
 		<options...>
@@ -155,7 +155,7 @@ The port for the server to use for HTTPS. For internal use only; does not change
 
 
 ##### `default_bind`
-The default bind address to be used for all sites, if the [`bind` directive](/docs/caddyfile/directives/bind) is not used in the site. Default: empty, which binds to all interfaces.
+The default bind address(es) to be used for all sites, if the [`bind` directive](/docs/caddyfile/directives/bind) is not used in the site. Default: empty, which binds to all interfaces.
 
 
 ##### `order`

--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -260,7 +260,8 @@ Because this command uses the API, the admin endpoint must not be disabled.
 <pre><code class="cmd bash">caddy reverse-proxy
 	[--from &lt;addr&gt;]
 	--to &lt;addr&gt;
-	[--change-host-header]</code></pre>
+	[--change-host-header]
+	[--internal-certs]</code></pre>
 
 Spins up a simple but production-ready HTTP(S) reverse proxy.
 
@@ -269,6 +270,8 @@ Spins up a simple but production-ready HTTP(S) reverse proxy.
 `--to` is the address to proxy to.
 
 `--change-host-header` will cause Caddy to change the Host header from the incoming value to the address of the upstream.
+
+`--internal-certs` will cause Caddy to issue certificates using its internal issuer (effectively self-signed) for the domain specified in the `--from` address.
 
 Both `--from` and `--to` parameters can be URLs, as scheme and domain name will be inferred from the provided URL (paths and query strings ignored). Or they can be a simple network address and not a complete URL.
 

--- a/src/docs/markdown/v2-upgrade.md
+++ b/src/docs/markdown/v2-upgrade.md
@@ -168,7 +168,7 @@ errors {
 
 ```
 handle_errors {
-	rewrite * /{http.error.status_code}.html
+	rewrite * /{err.status_code}.html
 	file_server
 }
 ```


### PR DESCRIPTION
Still TODO:

- [ ] CEL https://github.com/caddyserver/caddy/pull/4715 - need to document for each matcher their new `expression` syntax
- [ ] Admin `/adapt` endpoint https://github.com/caddyserver/caddy/pull/4846
- [ ] Admin `ETag` stuff https://github.com/caddyserver/caddy/pull/4579