### PR TITLE
download: add warning message for macOS users to unquarantine the binary

### DIFF
--- a/src/download.html
+++ b/src/download.html
@@ -74,6 +74,11 @@
 			<div class="text-center">
 				<span class="warning">⚠️ Only choose plugins you need and trust</span>
 			</div>
+			<div class="text-center" id="darwin-warning">
+				<span class="warning">⚠️ Run the following against the downloaded binary:
+					<code>xattr -d com.apple.quarantine </code>
+				</span>
+			</div>
 
 			<div id="optional-packages">
 				<!-- Populated by JavaScript -->

--- a/src/resources/css/download.css
+++ b/src/resources/css/download.css
@@ -62,6 +62,10 @@ body {
 	background: #333;
 }
 
+#darwin-warning {
+	display: none;
+}
+
 input:disabled,
 select:disabled,
 #optional-packages.disabled {

--- a/src/resources/js/download.js
+++ b/src/resources/js/download.js
@@ -245,7 +245,7 @@ function getDownloadLink() {
 
 		qs.append("p", p);
 	});
-
+	$("#darwin-warning").toggle(os === "darwin");
 	var idempotencyKey = Math.floor(Math.random() * 99999999999999);
 	qs.append("idempotency", idempotencyKey);
 


### PR DESCRIPTION
Recent releases of macOS automatically quarantine unsigned binaries downloaded from the internet. The internet is full of workarounds, including disabling this protection completely for the entire OS, which we don't want the users to stumble upon. The better workaround is to remove the quarantine bit using the command `xattr -d com.apple.quarantine`.

Given I had to swim through numerous pages to find this proper workaround, it seems reasonable we include a warning for the users on how to un-quarantine the binary to avoid them implementing the worse alternative of disabling the protection for the entire OS.