### PR TITLE
Fix basicauth documentation and example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/basicauth.md
+++ b/src/docs/markdown/caddyfile/directives/basicauth.md
@@ -27,7 +27,7 @@ basicauth [<matcher>] [<hash_algorithm> [<realm>]] {
 - **&lt;hash_algorithm&gt;** is the name of the password hashing algorithm (or KDF) used for the hashes in this configuration. Default: `bcrypt`
 - **&lt;realm&gt;** is a custom realm name.
 - **&lt;username&gt;** is a username or user ID.
-- **&lt;hashed_password&gt;** is the password hash.
+- **&lt;hashed_password&gt;** is the base-64 encoding of the password hash.
 - **&lt;salt_base64&gt;** is the base-64 encoding of the password salt, if an external salt is required.
 
 
@@ -37,7 +37,7 @@ Protect all resources in /secret so only Bob can access them with the password "
 
 ```caddy-d
 basicauth /secret/* {
-	Bob $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG
+	Bob JDJhJDE0JFpreDE5WExpVzZWWW91TEhSNU5tZk9GVTB6MkdUTm1wa1QvNXFxUjdoeDRJaldKUERoanZH
 }
 ```
 


### PR DESCRIPTION
Right now, the `basicauth` documentation says that the password hash for `basicauth` must be written as is. However, doing so results in an error when loading the config:

```
on: loading authentication providers: module name 'http_basic': provision http.authentication.providers.http_basic: base64-decoding password: illegal base64 data at input byte 0"}
```

base-64 encoding of the hash seems mandatory so this updates the documentation and the associated example