### PR TITLE
Add another handle_errors example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/handle_errors.md
+++ b/src/docs/markdown/caddyfile/directives/handle_errors.md
@@ -60,6 +60,20 @@ handle_errors {
 }
 ```
 
+If you want to provide custom error pages only for some error codes, you can check the existence of the custom error files beforehand with a [`file`](/docs/caddyfile/matchers#file) matcher:
+
+```caddy-d
+handle_errors {
+	@custom_err file /err-{http.error.status_code}.html /err.html
+	handle @custom_err {
+		rewrite @custom_err {http.matchers.file.relative}
+		file_server
+	}
+	respond "{http.error.status_code} {http.error.status_text}"
+}
+
+```
+
 Reverse proxy to a professional server that is highly qualified for handling HTTP errors and improving your day 😸:
 
 ```caddy-d


### PR DESCRIPTION
Not sure if this section NEEDS more examples, but this seems to be a pattern I come back to quite often: If a custom error page exists, use that file, otherwise deliver a "boring" error message. This was written in the hope to push users into writing "correct" error handlers and not something like

```
handle_errors {
	@404 expression `{http.error.status_code} == 404`
	try_files @404 /404.html
	file_server
}
```

(As seen in https://caddy.community/t/error-when-using-handle-errors-inside-route/13143, but I produced something similar before realizing my error)