### PR TITLE
docs: fix typo

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -26,7 +26,7 @@ Key points:
 
 - An optional [**global options block**](#global-options) can be the very first thing in the file.
 - Otherwise, the first line of the Caddyfile is **always** the [address(es)](#addresses) of the site to serve.
-- All [directives](#directives) and [matchers](#matchers) **must** go in a site block. There is no global scope or inheritence across site blocks.
+- All [directives](#directives) and [matchers](#matchers) **must** go in a site block. There is no global scope or inheritance across site blocks.
 - If there is only one site block, its curly braces `{ }` are optional.
 
 A Caddyfile consists of at least one or more site blocks, which always starts with one or more [addresses](#addresses) for the site. Any directives appearing before the address will be confusing to the parser.

--- a/src/docs/markdown/caddyfile/directives/handle.md
+++ b/src/docs/markdown/caddyfile/directives/handle.md
@@ -21,7 +21,7 @@ handle [<matcher>] {
 
 ## Utility
 
-If you prefer crafting HTTP handler logic in a more inheritence-based way like nginx location blocks, you may prefer the use of `handle` blocks rather than defining mutually-exclusive matchers for your directives. If inheritence is a desired characteristic of your HTTP handler configurations, then the `handle` directive may suit you well.
+If you prefer crafting HTTP handler logic in a more inheritance-based way like nginx location blocks, you may prefer the use of `handle` blocks rather than defining mutually-exclusive matchers for your directives. If inheritance is a desired characteristic of your HTTP handler configurations, then the `handle` directive may suit you well.
 
 ## Similar directives
 

--- a/src/docs/markdown/caddyfile/spec.md
+++ b/src/docs/markdown/caddyfile/spec.md
@@ -47,7 +47,7 @@ Tokens are then evaluated by the parser for structure.
 
 ## Structure
 
-A Caddyfile has no global scope or inheritence between separate blocks. The most global unit of the Caddyfile is an <b>entry</b>. An entry consists of a list of labels and a definition associated with those labels. A <b>label</b> is a string identifier, and a <b>definition</b> is a body (one or more lines) of tokens grouped together in a <i>block</i>:
+A Caddyfile has no global scope or inheritance between separate blocks. The most global unit of the Caddyfile is an <b>entry</b>. An entry consists of a list of labels and a definition associated with those labels. A <b>label</b> is a string identifier, and a <b>definition</b> is a body (one or more lines) of tokens grouped together in a <i>block</i>:
 
 <code class="block"><span class="cf-label-bg">list of labels</span>
 <span class="cf-block-bg">definition (block)</span></code>


### PR DESCRIPTION
Hi, because `inheritence` [seems to be a typo](https://www.merriam-webster.com/dictionary/inheritence). Thanks for awesome project.