### PR TITLE
pki: document certificate lifetime options

### DIFF
--- a/src/docs/markdown/caddyfile/directives/acme_server.md
+++ b/src/docs/markdown/caddyfile/directives/acme_server.md
@@ -18,9 +18,10 @@ Using ACME server defaults, ACME clients should simply be configured to use `htt
 
 ```caddy-d
 acme_server [<matcher>] {
-	ca <id>
+	ca       <id>
+	lifetime <duration>
 }
 ```
 
 - **ca** specifies the ID of the certificate authority with which to sign certificates. The default is `local`, which is Caddy's default CA, intended for locally-used, self-signed certificates, which is most common in dev environments. For broader use, it is recommended to specify a different CA to avoid confusion. If the CA with the given ID does not already exist, it will be created. See the [PKI app global options](/docs/caddyfile/options#pki-options) to configure alternate CAs.
-
+- **lifetime** (Default: `12h`) is a [duration](/docs/conventions#durations) which specifies the validity period for issued certificates. This value must be less than the lifetime of the [intermediate certificate](/docs/caddyfile/options#intermediate-lifetime) used for signing. It is not recommended to change this unless absolutely necessary.

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -115,9 +115,10 @@ Possible options are:
 	# PKI Options
 	pki {
 		ca [<id>] {
-			name            <name>
-			root_cn         <name>
-			intermediate_cn <name>
+			name                  <name>
+			root_cn               <name>
+			intermediate_cn       <name>
+			intermediate_lifetime <duration>
 			root {
 				format <format>
 				cert   <path>
@@ -445,6 +446,9 @@ The name to put in the CommonName field of the root certificate. Default: `{pki.
 
 ##### `intermediate_cn`
 The name to put in the CommonName field of the intermediate certificates. Default: `{pki.ca.name} - ECC Intermediate`
+
+##### `intermediate_lifetime`
+The [duration](/docs/conventions#durations) for which intermediate certificates are valid. This value must be less than the lifetime of the root cert (`3600d`). Default: `7d`. It is recommended not to change this unless absolutely necessary.
 
 ##### `root`
 A key pair (certificate and private key) to use as the root for the CA. If not specified, one will be generated and managed automatically.


### PR DESCRIPTION
This updates the documentation for `pki` and `acme_server` with details about the configuration options added for controlling intermediate and certificate lifetime added in https://github.com/caddyserver/caddy/pull/5232.