### PR TITLE
chore: typo fix in v2

### DIFF
--- a/src/v2.html
+++ b/src/v2.html
@@ -113,7 +113,7 @@
 							Caddy 2 is a <a href="/docs/extending-caddy">highly extensible</a>, self-hosted platform on which you can build, configure, and deploy long-running services ("apps").
 						</p>
 						<p>
-							Caddy ships with apps for an <a href="/docs/modules/http">HTTPS server</a> (static files, reverse proxing, load balancing, etc.), <a href="/docs/modules/tls">TLS certificate manager</a>, and <a href="/docs/modules/pki">fully-managed internal PKI</a>. Caddy apps collaborate to make complex infrastructure just work with fewer moving parts.
+							Caddy ships with apps for an <a href="/docs/modules/http">HTTPS server</a> (static files, reverse proxying, load balancing, etc.), <a href="/docs/modules/tls">TLS certificate manager</a>, and <a href="/docs/modules/pki">fully-managed internal PKI</a>. Caddy apps collaborate to make complex infrastructure just work with fewer moving parts.
 						</p>
 						<p>
 							<b>For example, the config shown here keeps your TLS certificates renewed for other programs to use;</b> no external tools or HTTP daemon required!


### PR DESCRIPTION
Everywhere else in the docs you use the term `proxying`, only in v2.html you use `proxing`, so I fixed this to be consistent. 