### PR TITLE
Add additional references to the directive order

### DIFF
--- a/src/docs/markdown/caddyfile/directives/redir.md
+++ b/src/docs/markdown/caddyfile/directives/redir.md
@@ -6,7 +6,7 @@ title: redir (Caddyfile directive)
 
 Issues an HTTP redirect to the client.
 
-This directive implies that a matched request is to be rejected. It is ordered very early in the handler chain (before [`rewrite`](/docs/caddyfile/directives/rewrite)).
+This directive implies that a matched request is to be rejected. It is ordered very early in the [handler chain](/docs/caddyfile/directives#directive-order) (before [`rewrite`](/docs/caddyfile/directives/rewrite)).
 
 
 ## Syntax

--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -573,7 +573,7 @@ If you're trying to serve a modern PHP application, you may be looking for the [
 
 The reverse proxy can be configured to intercept responses from the backend. To facilitate this, response matchers can be defined (similar to the syntax for request matchers) and the first matching `handle_response` route will be invoked.
 
-When a response handler is invoked, the response from the backend is not written to the client, and the configured `handle_response` route will be executed instead, and it is up to that route to write a response. If the route does _not_ write a response, then request handling will continue with any handlers that are ordered after this `reverse_proxy`.
+When a response handler is invoked, the response from the backend is not written to the client, and the configured `handle_response` route will be executed instead, and it is up to that route to write a response. If the route does _not_ write a response, then request handling will continue with any handlers that are [ordered after](/docs/caddyfile/directives#directive-order) this `reverse_proxy`.
 
 - **@name** is the name of a [response matcher](#response-matcher). As long as each response matcher has a unique name, multiple matchers can be defined. A response can be matched on the status code and presence or value of a response header.
 - **replace_status** <span id="replace_status"/> simply changes the status code of response when matched by the given matcher.

--- a/src/docs/markdown/caddyfile/directives/route.md
+++ b/src/docs/markdown/caddyfile/directives/route.md
@@ -6,7 +6,7 @@ title: route (Caddyfile directive)
 
 Evaluates a group of directives literally and as a single unit.
 
-Directives contained in a route block will not be reordered internally. Only HTTP handler directives (directives which add handlers or middleware to the chain) can be used in a route block.
+Directives contained in a route block will not be [reordered internally](/docs/caddyfile/directives#directive-order). Only HTTP handler directives (directives which add handlers or middleware to the chain) can be used in a route block.
 
 This directive is a special case in that its subdirectives are also regular directives.
 


### PR DESCRIPTION
Depending on which directives you look at, there are no links to the directive order. This adds a reference to some of the most commonly used directive-docs.

References: #293