### PR TITLE
docs: mention nixpkgs on install page

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -29,6 +29,7 @@ Our [official packages](https://github.com/caddyserver/dist) come only with the 
 - [Ansible](#ansible)
 - [Scoop](#scoop)
 - [Termux](#termux)
+- [Nix/Nixpkgs/NixOS](#nixnixpkgsnixos)
 
 
 ## Static binaries
@@ -169,3 +170,12 @@ _Note: This is a community-maintained installation method._
 
 [**View the Termux build.sh file**](https://github.com/termux/termux-packages/blob/master/packages/caddy/build.sh)
 
+
+## Nix/Nixpkgs/NixOS
+
+_Note: This is a community-maintained installation method._
+
+- Package name: [`caddy`](https://search.nixos.org/packages?channel=unstable&show=caddy&query=caddy)
+- NixOS module: [`services.caddy`](https://search.nixos.org/options?channel=unstable&show=services.caddy.enable&query=services.caddy)
+
+[**View Caddy in the Nixpkgs search**](https://search.nixos.org/packages?channel=unstable&show=caddy&query=caddy) and [**the NixOS options search**](https://search.nixos.org/options?channel=unstable&show=services.caddy.enable&query=services.caddy)


### PR DESCRIPTION
Very simple addition.

I don't think it makes all that much sense to add literal commands on how to install the package, unlike the other install sources.

The link to https://search.nixos.org/packages?channel=unstable&show=caddy&query=caddy already shows multiple ways of doing that, and more importantly, are kept updated automatically.

Similarly, I didn't link to the underlying `.nix` source files, as those can be easily found by clicking on `📦 Source` on the package search or `Declared in` for any [option of the NixOS module](https://search.nixos.org/options?channel=unstable&show=services.caddy.enable&query=services.caddy).
Especially considering the package's build file location might change soon (RFC 0140).

And the NixOS module (not the package!) uses a slightly modified systemd service, so technically a similar warning as the one from ArchLinux does apply.
But I feel like most NixOS users are perfectly aware that modules often come with some modifications to the vanilla service :thinking: 