### PR TITLE
Introduce tabbed sections in Markdown, Docker docs

### DIFF
--- a/src/includes/head.html
+++ b/src/includes/head.html
@@ -37,3 +37,7 @@
 	gtag('js', new Date());
 	gtag('config', 'G-2DLB04LK4P');
 </script>
+
+<!-- Alpine.js to augment markdown docs -->
+<script src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>

--- a/src/resources/css/docs.css
+++ b/src/resources/css/docs.css
@@ -789,7 +789,49 @@ td code {
 
 
 
+.tabs .tab-buttons {
+	display: flex;
+	font-size: 0;
+	border-bottom: 2px solid #ccc;
+	border-radius: 0.5em;
+	margin: 0 16px 0 16px;
+}
+.tabs .tab-buttons button {
+	font-family: inherit;
+	border-radius: 0.5em 0.5em 0 0;
+	background-color: transparent;
+	border: 2px solid;
+	border-color: transparent;
+	font-size: 16px;
+	margin-bottom: 0;
+	margin-right: 8px;
+	margin-bottom: -2px;
+	transition: unset;
+	transform: unset;
+}
+.tabs .tab-buttons button:hover {
+	border-color: #ddd;
+	border-bottom-color: #ccc;
+}
+.tabs .tab-buttons button.active {
+	border-color: #ccc;
+	border-bottom-color: white;
+}
 
+.tabs .tab {
+	border-style: solid;
+	border-color: #ccc;
+	border-width: 0;
+	padding: 1.5rem 16px 0 20px;
+	margin-top: -2px;
+}
+.tabs .tab pre {
+	padding: 0;
+}
+.tabs .tab.bordered {
+	border-width: 2px;
+	border-radius: 8px;
+}
 
 
 
@@ -1026,5 +1068,23 @@ td code {
 	th,
 	td {
 		border-bottom-color: #233444;
+	}
+
+	.tabs .tab-buttons {
+		border-color: #33659a;
+	}
+	.tabs .tab-buttons button {
+		color: #bdd6f7;
+	}
+	.tabs .tab-buttons button:hover {
+		border-color: #284c71;
+		border-bottom-color: #33659a;
+	}
+	.tabs .tab-buttons button.active {
+		border-color: #33659a;
+		border-bottom-color: #051628;
+	}
+	.tabs .tab {
+		border-color: #33659a;
 	}
 }

--- a/src/resources/js/common.js
+++ b/src/resources/js/common.js
@@ -34,3 +34,48 @@ function moduleDocsPreview(mod, maxLen) {
 	}
 	return short;
 }
+
+function detectPlatform() {
+	// assume 32-bit linux, then change OS and architecture if justified
+	var os = "linux", arch = "amd64";
+
+	// change os
+	if (/Macintosh/i.test(navigator.userAgent)) {
+		os = "darwin";
+	} else if (/Windows/i.test(navigator.userAgent)) {
+		os = "windows";
+	} else if (/FreeBSD/i.test(navigator.userAgent)) {
+		os = "freebsd";
+	} else if (/OpenBSD/i.test(navigator.userAgent)) {
+		os = "openbsd";
+	}
+
+	// change architecture
+	if (os == "darwin" || /amd64|x64|x86_64|Win64|WOW64|i686|64-bit/i.test(navigator.userAgent)) {
+		arch = "amd64";
+	} else if (/arm64/.test(navigator.userAgent)) {
+		arch = "arm64";
+	} else if (/ ARM| armv/.test(navigator.userAgent)) {
+		arch = "arm";
+	}
+
+	// change arm version
+	if (arch == "arm") {
+		var arm = "7"; // assume version 7 by default
+		if (/armv6/.test(navigator.userAgent)) {
+			arm = "6";
+		} else if (/armv5/.test(navigator.userAgent)) {
+			arm = "5";
+		}
+		arch += arm;
+	}
+
+	return [os, arch];
+}
+
+// Detect the platform OS, but with an allow-list of values
+// and if the value is not allowed, return the default.
+function defaultOS(allowed, def) {
+	var [os] = detectPlatform();
+	return allowed.includes(os) ? os : def;
+}

--- a/src/resources/js/download.js
+++ b/src/resources/js/download.js
@@ -174,45 +174,8 @@ $(function() {
 // autoPlatform chooses the platform in the list that best
 // matches the user's browser, if it's available.
 function autoPlatform() {
-	// assume 32-bit linux, then change OS and architecture if justified
-	var os = "linux", arch = "amd64", arm = "";
-
-	// change os
-	if (/Macintosh/i.test(navigator.userAgent)) {
-		os = "darwin";
-	} else if (/Windows/i.test(navigator.userAgent)) {
-		os = "windows";
-	} else if (/FreeBSD/i.test(navigator.userAgent)) {
-		os = "freebsd";
-	} else if (/OpenBSD/i.test(navigator.userAgent)) {
-		os = "openbsd";
-	}
-
-	// change architecture
-	if (os == "darwin" || /amd64|x64|x86_64|Win64|WOW64|i686|64-bit/i.test(navigator.userAgent)) {
-		arch = "amd64";
-	} else if (/arm64/.test(navigator.userAgent)) {
-		arch = "arm64";
-	} else if (/ ARM| armv/.test(navigator.userAgent)) {
-		arch = "arm";
-	}
-
-	// change arm version
-	if (arch == "arm") {
-		arm = "7"; // assume version 7 by default
-		if (/armv6/.test(navigator.userAgent)) {
-			arm = "6";
-		} else if (/armv5/.test(navigator.userAgent)) {
-			arm = "5";
-		}
-	}
-
-	var selString = os+"-"+arch;
-	if (arm != "") {
-		selString += "-"+arm;
-	}
-
-	$('#platform').val(selString);
+	var [os, arch] = detectPlatform();
+	$('#platform').val(os+"-"+arch);
 	updatePage();
 }
 


### PR DESCRIPTION
For quite a while now, I've wanted a way to have sections in the docs that are platform-specific hidden behind tabs.

This is super easy to do with a library like https://alpinejs.dev since it allows us to do it entirely inline within markup.

Preview of what it looks like (GIF):

![firefox_IZ2mblLKF1](https://user-images.githubusercontent.com/2111701/226241436-3d20944a-94b4-44d9-aa05-958bc216b519.gif)

- Pulling Alpine from CDNs because it's lower maintenance to do so and we get the latest patch versions automatically which is nice.
- We use `x-data` to define the default value for the tab. Then, `x-on:click` is used to update the value, and `x-show` is a condition to only show the tab content if the chosen tab matches. `x-bind:class` is used to add the `active` class for the current tab.
- For the tab's data, since we care to show the user the docs for their current OS, I'm reusing the platform detection logic we had for `download.html` but I'm moving it to `common.js` so that I can use it here as well. Made a helper `defaultOS()` since the detected OS might be something else like `solaris` (lol) which we don't have instructions for, so I need to validate against the ones supported by the tabs.
- I pulled in the `persist` plugin as well https://alpinejs.dev/plugins/persist which adds the `$persist()` function to make data persist across page navigation. When we expand the usage of this, it would mean that we could share the data across all pages etc.
- Notice that I put newlines around the content of the `<div x-show>`. This is so that the content within is rendered as Markdown (obviously in this case there's no "markdown" since it's just a `<pre><code>`). In general, there would be textual content and we want that to be caught by our markdown parser so those newlines are key to making that work.
- I took a shot at doing some CSS that makes sense and fits with the docs theme. The colors and border width could use some tweaking maybe. I hand picked the dark theme color to be lightly darker than the border we use for `<h1>` because that was too bright for this. The border color for light theme is pretty uninspired, I'm not sure what to do with it; should it be blue tinted as well? I use the dark theme so I have a better feel for how the dark theme should look. Feel free to fix the CSS on this branch @mholt

So that's the spiel about Alpine. But in addition to that, this PR's triggering motivation was a want to improve the Docker docs a bit:

- I found https://github.com/dunglas/symfony-docker/blob/main/docs/tls.md earlier today, they mention some commands that can be used to install the root CA cert on the host machine. These are nice and clean commands, so I wanted to pull that idea into our docs because it's a question we get a lot. /cc @dunglas thanks for that (I don't think you authored it but it is your repo 😅)

  I've always struggled with how to make this easier for users. My thought for the past couple years was "we have `caddy trust`, how can we make it possible to users to run that on their host machine?", but the reality is, that's not really viable. It would mean they'd need to have a Caddy binary on the host as well, but they're using Docker specifically so they don't need it on the host. So this is essentially me giving up on that idea. I've been telling people "google it" for how to install the cert on their platform when asked on the forums, but that's not great.

  The other limitation here is obviously that this doesn't attempt to install the root CA cert in browser trust stores. We might need to augment the documented command to do that at some point. I dunno. Seems annoying 😬. It's essentially redoing work that https://github.com/smallstep/truststore already handles. Bah.

- Docker Compose V2 doesn't use a `-` anymore, wanted to clarify that clearly.

- Some beginners might not have a clue what the docker-compose.yml does, figured I could add a bit of explanation about each part.

- Added an aside noting that `localhost` doesn't do what many users expect in Docker for `reverse_proxy`.

- Added a bit more to the logs command to make it more useful by default. Typically users want their most recent logs, not their oldest. So using `-n` and `-f` helps with that.