### PR TITLE
handle_errors: use `replace_status` for proxy example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/handle_errors.md
+++ b/src/docs/markdown/caddyfile/directives/handle_errors.md
@@ -80,6 +80,7 @@ handle_errors {
 	rewrite * /{err.status_code}
 	reverse_proxy https://http.cat {
 		header_up Host {upstream_hostport}
+		replace_status {err.status_code}
 	}
 }
 ```


### PR DESCRIPTION
Hi, I actually used the `http.cat` handle_error snippet in my website and realized that any errors are logged as 200 in access logs. adding `replace_status` directive fixed the issue.