### PR TITLE
reverse_proxy: rewrite method to GET for X-Accel-Redirect support.

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -684,6 +684,7 @@ reverse_proxy localhost:8080 {
 	handle_response @accel {
 		root    * /path/to/private/files
 		rewrite * {rp.header.X-Accel-Redirect}
+		method  * GET
 		file_server
 	}
 }


### PR DESCRIPTION
There are cases where non-GET-or-HEAD requests will need to send files using X-Accel-Redirect, which will caddy reject with `405 Method not allowed` since file_server only accepts GET and HEAD request (https://github.com/caddyserver/caddy/commit/a3ae146cbdf2cfbdbdf5feea52e8bf407cce2b31)

This is based on https://github.com/caddyserver/caddy/issues/5529