### PR TITLE
cli: document the new command `file-server export-template`

### DIFF
--- a/src/docs/markdown/caddyfile/directives/file_server.md
+++ b/src/docs/markdown/caddyfile/directives/file_server.md
@@ -48,7 +48,7 @@ file_server [<matcher>] [browse] {
 
 - **browse** <span id="browse"/> enables file listings for requests to directories that do not have an index file.
 
-  - **<template_file>** <span id="template_file"/> is an optional custom template file to use for directory listings. Defaults to the template that can be found [here in the source code ![external link](/resources/images/external-link.svg)](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/fileserver/browse.html). Browse templates can use actions from [the standard templates module](/docs/modules/http.handlers.templates#docs) as well.
+  - **<template_file>** <span id="template_file"/> is an optional custom template file to use for directory listings. Defaults to the template that can be extracted using the command `caddy file-server export-template`, which will print the defaut template to stdout. The embedded template can also be found [here in the source code ![external link](/resources/images/external-link.svg)](https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/fileserver/browse.html). Browse templates can use actions from [the standard templates module](/docs/modules/http.handlers.templates#docs) as well.
 
 - **precompressed** <span id="precompressed"/> is the list of encoding formats to search for precompressed sidecar files. Arguments are an ordered list of encoding formats to search for precompressed [sidecar files](https://en.wikipedia.org/wiki/Sidecar_file). Supported formats are `gzip` (`.gz`), `zstd` (`.zst`) and `br` (`.br`).
 

--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -35,6 +35,9 @@ The ellipses `...` indicates a continuation, i.e. one or more parameters.
 - **[caddy file-server](#caddy-file-server)**
   A simple but production-ready file server
 
+- **[caddy file-server export-template](#caddy-file-server-export-template)**
+  Auxilary command for the file server to export the default file browser template
+
 - **[caddy fmt](#caddy-fmt)**
   Formats a Caddyfile
 
@@ -202,7 +205,11 @@ Spins up a simple but production-ready static file server.
 This command disables the admin API, making it easier to run multiple instances on a local development machine.
 
 
+#### `caddy file-server export-template`
 
+<pre><code class="cmd bash">caddy file-server export-template</code></pre>
+
+Exports the default file browsing template to stdout
 
 ### `caddy fmt`
 


### PR DESCRIPTION
I'm not sure if there's a better way to document sub-command. Any other thoughts beside plainly listing it like any other?