### PR TITLE
signature-verification: accommodate changes in cosign cli behavior and add tldr

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -38,7 +38,7 @@ Our [official packages](https://github.com/caddyserver/dist) come only with the 
 
 1. Obtain a Caddy binary:
 	- [from releases on GitHub](https://github.com/caddyserver/caddy/releases) (expand "Assets")
-		- Refer to [Verifying Asset Signatures](/docs/signature-verification) for how to verify the asset signature
+		- Refer to [Asset Signature Verification](/docs/signature-verification) for how to verify the asset signature
 	- [from our download page](/download)
 	- [by building from source](/docs/build) (either with `go` or `xcaddy`)
 2. [Install Caddy as a system service.](/docs/running#manual-installation) This is strongly recommended, especially for production servers.

--- a/src/docs/markdown/signature-verification.md
+++ b/src/docs/markdown/signature-verification.md
@@ -10,7 +10,7 @@ As of Caddy v2.6.0, CI/CD release artifacts are signed using project [Sigstore](
 
 <aside class="tip" id="tldr">
 
-tl;dr: The following code snippet will verify the signature of a Caddy release artifact, keeping in mind the necessity to accommodate the URLs and the subject artificat name:
+tl;dr: The following code snippet will verify the signature of a Caddy release artifact, keeping in mind the necessity to accommodate the URLs and the subject artifact name:
 <pre><code class="cmd">
 <span class="bash">TAG="2.6.0"</span>
 <span class="bash">ARTIFACT="caddy_${TAG}_checksums.txt"</span>

--- a/src/includes/docs/nav.html
+++ b/src/includes/docs/nav.html
@@ -47,7 +47,7 @@
 		<li><a href="/docs/metrics">Monitoring Caddy</a></li>
 		<li><a href="/docs/architecture">Caddy Architecture</a></li>
 		<li><a href="/docs/running">Keep Caddy Running</a></li>
-		<li><a href="/docs/signature-verification">Verifying Asset Signatures</a></li>
+		<li><a href="/docs/signature-verification">Asset Signature Verification</a></li>
 
 		<li class="heading">Developers</li>
 		<li>


### PR DESCRIPTION
TODO:
- [ ] Figure out how to fetch UUID of tlog entry using `cosign` to retain the multi-perspective verification

This is how the tldr looks

![image](https://github.com/caddyserver/website/assets/2636183/069d72ee-93f4-40f5-9637-55b935e6a482)


Closes #312