### PR TITLE
running: Notes about SELinux

### DIFF
--- a/src/docs/markdown/running.md
+++ b/src/docs/markdown/running.md
@@ -7,19 +7,18 @@ title: Keep Caddy Running
 While Caddy can be run directly with its [command line interface](/docs/command-line), there are numerous advantages to using a service manager to keep it running, such as ensuring it starts automatically when the system reboots and to capture stdout/stderr logs.
 
 
-- [Keep Caddy Running](#keep-caddy-running)
-  - [Linux Service](#linux-service)
-    - [Unit Files](#unit-files)
-    - [Manual Installation](#manual-installation)
-    - [Using the Service](#using-the-service)
-    - [Overrides](#overrides)
-    - [SELinux System Considerations](#selinux-system-considerations)
-  - [Windows service](#windows-service)
-    - [sc.exe](#scexe)
-    - [WinSW](#winsw)
-  - [Docker Compose](#docker-compose)
-    - [Setup](#setup)
-    - [Usage](#usage)
+- [Linux Service](#linux-service)
+  - [Unit Files](#unit-files)
+  - [Manual Installation](#manual-installation)
+  - [Using the Service](#using-the-service)
+  - [Overrides](#overrides)
+  - [SELinux System Considerations](#selinux-system-considerations)
+- [Windows service](#windows-service)
+  - [sc.exe](#scexe)
+  - [WinSW](#winsw)
+- [Docker Compose](#docker-compose)
+  - [Setup](#setup)
+  - [Usage](#usage)
 
 
 ## Linux Service
@@ -156,7 +155,7 @@ RestartSec=5s
 Then, save the file and exit the text editor, and restart the service for it to take effect:
 <pre><code class="cmd bash">sudo systemctl restart caddy</code></pre>
 
-### SELinux System Considerations
+### SELinux Considerations
 
 On SELinux enabled systems you have two options:
 1. Install Caddy using the [COPR repo](https://copr.fedorainfracloud.org/coprs/g/caddy/caddy/). Your systemd file and caddy binary will be created and labelled correctly. If you wish to use a custom build of Caddy, you'll need to label the executable as described below.
@@ -167,8 +166,7 @@ Systemd unit files and their executables will not be run unless labelled with `s
 The `systemd_unit_file_t` is automatically applied to files created in `/etc/systemd/...`, so be sure to create your `caddy.service` file there.
 
 To tag the caddy binary, you can use the following commands:
-<pre><code class="cmd bash">semanage fcontext -a -t bin_t /usr/bin/caddy
-restorecon -Rv /usr/bin/caddy
+<pre><code class="cmd bash">semanage fcontext -a -t bin_t /usr/bin/caddy && restorecon -Rv /usr/bin/caddy
 </code></pre>
 
 ## Windows service

--- a/src/docs/markdown/running.md
+++ b/src/docs/markdown/running.md
@@ -12,6 +12,7 @@ While Caddy can be run directly with its [command line interface](/docs/command-
   - [Manual Installation](#manual-installation)
   - [Using the Service](#using-the-service)
   - [Overrides](#overrides)
+  - [SELinux System Considerations](#selinux-system-considerations)
 - [Windows Service](#windows-service)
 - [Docker Compose](#docker-compose)
   - [Setup](#setup)
@@ -151,6 +152,25 @@ RestartSec=5s
 
 Then, save the file and exit the text editor, and restart the service for it to take effect:
 <pre><code class="cmd bash">sudo systemctl restart caddy</code></pre>
+
+### SELinux System Considerations
+
+On SELinux enabled systems, systemd unit files and their executables will not be run unless labelled with `systemd_unit_file_t` and `bin_t` respectively.
+
+Moreover on some distros (Fedora), SELinux will not let you relabel files directly placed in `/etc/systemd/system`. Instead unit files inside `/etc/systemd/system/` are symlinks to `/usr/lib/systemd/system/`. 
+
+If that is the case, you could create the `caddy.service` file inside the `/usr/lib/` directory and symlink it to `/etc/systemd/system/caddy.service`.
+
+```shell
+### symlink the file if your selinux policy doesn't allow labelling files in /etc/systemd/
+ln -s /usr/lib/systemd/system/caddy.service /etc/systemd/system/caddy.service
+
+semanage fcontext -a -t systemd_unit_file_t PATH_TO_UNIT_FILE
+restorecon -Rv PATH_TO_UNIT_FILE
+
+semanage fcontext -a -t bin_t /usr/bin/caddy
+restorecon -Rv /usr/bin/caddy
+```
 
 
 ## Windows service

--- a/src/docs/markdown/running.md
+++ b/src/docs/markdown/running.md
@@ -157,17 +157,10 @@ Then, save the file and exit the text editor, and restart the service for it to 
 
 On SELinux enabled systems, systemd unit files and their executables will not be run unless labelled with `systemd_unit_file_t` and `bin_t` respectively.
 
-Moreover on some distros (Fedora), SELinux will not let you relabel files directly placed in `/etc/systemd/system`. Instead unit files inside `/etc/systemd/system/` are symlinks to `/usr/lib/systemd/system/`. 
+The `systemd_unit_file_t` is automatically applied to files created in `/etc/systemd/...`, so be sure to create your `caddy.service` file there.
 
-If that is the case, you could create the `caddy.service` file inside the `/usr/lib/` directory and symlink it to `/etc/systemd/system/caddy.service`.
-
+To tag the caddy binary, you can use the following commands:
 ```shell
-### symlink the file if your selinux policy doesn't allow labelling files in /etc/systemd/
-ln -s /usr/lib/systemd/system/caddy.service /etc/systemd/system/caddy.service
-
-semanage fcontext -a -t systemd_unit_file_t PATH_TO_UNIT_FILE
-restorecon -Rv PATH_TO_UNIT_FILE
-
 semanage fcontext -a -t bin_t /usr/bin/caddy
 restorecon -Rv /usr/bin/caddy
 ```

--- a/src/docs/markdown/running.md
+++ b/src/docs/markdown/running.md
@@ -7,16 +7,19 @@ title: Keep Caddy Running
 While Caddy can be run directly with its [command line interface](/docs/command-line), there are numerous advantages to using a service manager to keep it running, such as ensuring it starts automatically when the system reboots and to capture stdout/stderr logs.
 
 
-- [Linux Service](#linux-service)
-  - [Unit Files](#unit-files)
-  - [Manual Installation](#manual-installation)
-  - [Using the Service](#using-the-service)
-  - [Overrides](#overrides)
-  - [SELinux System Considerations](#selinux-system-considerations)
-- [Windows Service](#windows-service)
-- [Docker Compose](#docker-compose)
-  - [Setup](#setup)
-  - [Usage](#usage)
+- [Keep Caddy Running](#keep-caddy-running)
+  - [Linux Service](#linux-service)
+    - [Unit Files](#unit-files)
+    - [Manual Installation](#manual-installation)
+    - [Using the Service](#using-the-service)
+    - [Overrides](#overrides)
+    - [SELinux System Considerations](#selinux-system-considerations)
+  - [Windows service](#windows-service)
+    - [sc.exe](#scexe)
+    - [WinSW](#winsw)
+  - [Docker Compose](#docker-compose)
+    - [Setup](#setup)
+    - [Usage](#usage)
 
 
 ## Linux Service
@@ -155,7 +158,12 @@ Then, save the file and exit the text editor, and restart the service for it to 
 
 ### SELinux System Considerations
 
-On SELinux enabled systems, systemd unit files and their executables will not be run unless labelled with `systemd_unit_file_t` and `bin_t` respectively.
+On SELinux enabled systems you have two options:
+1. Compile Caddy and label the files yourself
+2. Install Caddy using the [COPR repo](https://copr.fedorainfracloud.org/coprs/g/caddy/caddy/), your systemd file and caddy binary will be created and labelled correctly. NB: if you want to recompile Caddy with modules, you will have to label the executable as described bellow.
+   
+
+Systemd unit files and their executables will not be run unless labelled with `systemd_unit_file_t` and `bin_t` respectively.
 
 The `systemd_unit_file_t` is automatically applied to files created in `/etc/systemd/...`, so be sure to create your `caddy.service` file there.
 

--- a/src/docs/markdown/running.md
+++ b/src/docs/markdown/running.md
@@ -160,7 +160,7 @@ Then, save the file and exit the text editor, and restart the service for it to 
 
 On SELinux enabled systems you have two options:
 1. Install Caddy using the [COPR repo](https://copr.fedorainfracloud.org/coprs/g/caddy/caddy/). Your systemd file and caddy binary will be created and labelled correctly. If you wish to use a custom build of Caddy, you'll need to label the executable as described below.
-2. [Download](https://caddyserver.com/download) Caddy from the site, or compile it with *xcaddy*. In both cases you will need to label the files yourself.
+2. [Download Caddy from this site](https://caddyserver.com/download) or compile it with [`xcaddy`](https://github.com/caddyserver/xcaddy). In both cases you will need to label the files yourself.
 
 Systemd unit files and their executables will not be run unless labelled with `systemd_unit_file_t` and `bin_t` respectively.
 

--- a/src/docs/markdown/running.md
+++ b/src/docs/markdown/running.md
@@ -159,7 +159,7 @@ Then, save the file and exit the text editor, and restart the service for it to 
 ### SELinux System Considerations
 
 On SELinux enabled systems you have two options:
-1. Install Caddy using the [COPR repo](https://copr.fedorainfracloud.org/coprs/g/caddy/caddy/), your systemd file and caddy binary will be created and labelled correctly. If you wish to use a custom build of Caddy, you'll need to label the executable as described below.
+1. Install Caddy using the [COPR repo](https://copr.fedorainfracloud.org/coprs/g/caddy/caddy/). Your systemd file and caddy binary will be created and labelled correctly. If you wish to use a custom build of Caddy, you'll need to label the executable as described below.
 2. [Download](https://caddyserver.com/download) Caddy from the site, or compile it with *xcaddy*. In both cases you will need to label the files yourself.
 
 Systemd unit files and their executables will not be run unless labelled with `systemd_unit_file_t` and `bin_t` respectively.

--- a/src/docs/markdown/running.md
+++ b/src/docs/markdown/running.md
@@ -159,20 +159,17 @@ Then, save the file and exit the text editor, and restart the service for it to 
 ### SELinux System Considerations
 
 On SELinux enabled systems you have two options:
-1. Compile Caddy and label the files yourself
-2. Install Caddy using the [COPR repo](https://copr.fedorainfracloud.org/coprs/g/caddy/caddy/), your systemd file and caddy binary will be created and labelled correctly. NB: if you want to recompile Caddy with modules, you will have to label the executable as described bellow.
-   
+1. Install Caddy using the [COPR repo](https://copr.fedorainfracloud.org/coprs/g/caddy/caddy/), your systemd file and caddy binary will be created and labelled correctly. If you wish to use a custom build of Caddy, you'll need to label the executable as described below.
+2. [Download](https://caddyserver.com/download) Caddy from the site, or compile it with *xcaddy*. In both cases you will need to label the files yourself.
 
 Systemd unit files and their executables will not be run unless labelled with `systemd_unit_file_t` and `bin_t` respectively.
 
 The `systemd_unit_file_t` is automatically applied to files created in `/etc/systemd/...`, so be sure to create your `caddy.service` file there.
 
 To tag the caddy binary, you can use the following commands:
-```shell
-semanage fcontext -a -t bin_t /usr/bin/caddy
+<pre><code class="cmd bash">semanage fcontext -a -t bin_t /usr/bin/caddy
 restorecon -Rv /usr/bin/caddy
-```
-
+</code></pre>
 
 ## Windows service
 


### PR DESCRIPTION
Hello,

I've added minor documentation as to how you would install a systemd Unit file for Caddy on an SELinux enabled system.

This was tested on Fedora, I unfortunately don't have another distro to try it on.

In any case, I hope this helps, and thanks for all the existing doc' !

