### PR TITLE
Implement cache busting

### DIFF
--- a/src/account/create.html
+++ b/src/account/create.html
@@ -2,8 +2,9 @@
 <html>
 	<head>
 		<title>Create Account - Caddy</title>
-		{{include "/includes/account/head.html"}}
-		<script src="/resources/js/account/create.js"></script>
+		{{import "/includes/account/head.html"}}
+		{{template "account-head"}}
+		<script src="/resources/js/account/create.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		<form action="/api/create-account" class="card">

--- a/src/account/index.html
+++ b/src/account/index.html
@@ -2,9 +2,10 @@
 <html>
 	<head>
 		<title>Dashboard - Caddy</title>
-		{{include "/includes/account/head.html"}}
-		<link rel="stylesheet" href="/resources/css/account/dashboard.css">
-		<script src="/resources/js/account/dashboard.js"></script>
+		{{import "/includes/account/head.html"}}
+		{{template "account-head"}}
+		<link rel="stylesheet" href="/resources/css/account/dashboard.css{{template "cacheBust"}}">
+		<script src="/resources/js/account/dashboard.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		<div class="container">

--- a/src/account/login.html
+++ b/src/account/login.html
@@ -2,8 +2,9 @@
 <html>
 	<head>
 		<title>Log In - Caddy</title>
-		{{include "/includes/account/head.html"}}
-		<script src="/resources/js/account/login.js"></script>
+		{{import "/includes/account/head.html"}}
+		{{template "account-head"}}
+		<script src="/resources/js/account/login.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		<form action="/api/login" class="card">

--- a/src/account/logout.html
+++ b/src/account/logout.html
@@ -2,8 +2,9 @@
 <html>
 	<head>
 		<title>Logout - Caddy</title>
-		{{include "/includes/account/head.html"}}
-		<script src="/resources/js/account/logout.js"></script>
+		{{import "/includes/account/head.html"}}
+		{{template "account-head"}}
+		<script src="/resources/js/account/logout.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		Logging out...

--- a/src/account/register-package.html
+++ b/src/account/register-package.html
@@ -2,8 +2,9 @@
 <html>
 	<head>
 		<title>Register Package - Caddy</title>
-		{{include "/includes/account/head.html"}}
-		<script src="/resources/js/account/register-package.js"></script>
+		{{import "/includes/account/head.html"}}
+		{{template "account-head"}}
+		<script src="/resources/js/account/register-package.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		<div class="container">

--- a/src/account/reset-password.html
+++ b/src/account/reset-password.html
@@ -2,8 +2,9 @@
 <html>
 	<head>
 		<title>Reset Password - Caddy</title>
-		{{include "/includes/account/head.html"}}
-		<script src="/resources/js/account/reset-password.js"></script>
+		{{import "/includes/account/head.html"}}
+		{{template "account-head"}}
+		<script src="/resources/js/account/reset-password.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		<form action="/api/reset-password" class="card" id="reset-password-step1">

--- a/src/account/verify.html
+++ b/src/account/verify.html
@@ -2,8 +2,9 @@
 <html>
 	<head>
 		<title>Confirm Account - Caddy</title>
-		{{include "/includes/account/head.html"}}
-		<script src="/resources/js/account/verify.js"></script>
+		{{import "/includes/account/head.html"}}
+		{{template "account-head"}}
+		<script src="/resources/js/account/verify.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		<form action="/api/verify-account" class="card">

--- a/src/business.html
+++ b/src/business.html
@@ -2,7 +2,8 @@
 <html>
 	<head>
 		<title>Caddy for Business</title>
-		{{include "/includes/head.html"}}
+		{{import "/includes/head.html"}}
+		{{template "head"}}
 		<link rel="stylesheet" href="/resources/css/business.css">
 		<meta property="og:title" content="Caddy 2 for Business">
 		<meta name="twitter:title" value="Caddy 2 for Business">

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -8,7 +8,8 @@
 <html>
 	<head>
 		<title>{{$title}} &mdash; Caddy Documentation</title>
-		{{include "/includes/docs/head.html"}}
+		{{import "/includes/docs/head.html"}}
+		{{template "docs-head"}}
 		<meta property="og:title" content="{{$title}} - Caddy Documentation">
 		<meta name="twitter:title" value="{{$title}} - Caddy Documentation">
 	</head>

--- a/src/docs/json/index.html
+++ b/src/docs/json/index.html
@@ -2,11 +2,12 @@
 <html>
 	<head>
 		<title>JSON Config Structure - Caddy Documentation</title>
-		{{include "/includes/docs/head.html"}}
-		<link rel="stylesheet" href="/resources/css/docs-json.css">
+		{{import "/includes/docs/head.html"}}
+		{{template "docs-head"}}
+		<link rel="stylesheet" href="/resources/css/docs-json.css{{template "cacheBust"}}">
 		<script src="/resources/js/marked-0.8.0.min.js"></script>
-		<script src="/resources/js/docs-api.js"></script>
-		<script src="/resources/js/json-docs.js"></script>
+		<script src="/resources/js/docs-api.js{{template "cacheBust"}}"></script>
+		<script src="/resources/js/json-docs.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		{{include "/includes/docs/header.html"}}

--- a/src/docs/modules/index.html
+++ b/src/docs/modules/index.html
@@ -2,11 +2,12 @@
 <html>
 	<head>
 		<title>Modules - Caddy Documentation</title>
-		{{include "/includes/docs/head.html"}}
-		<link rel="stylesheet" href="/resources/css/docs-json.css">
+		{{import "/includes/docs/head.html"}}
+		{{template "docs-head"}}
+		<link rel="stylesheet" href="/resources/css/docs-json.css{{template "cacheBust"}}">
 		<script src="/resources/js/marked-0.8.0.min.js"></script>
-		<script src="/resources/js/docs-api.js"></script>
-		<script src="/resources/js/module-docs.js"></script>
+		<script src="/resources/js/docs-api.js{{template "cacheBust"}}"></script>
+		<script src="/resources/js/module-docs.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		{{include "/includes/docs/header.html"}}

--- a/src/download.html
+++ b/src/download.html
@@ -2,11 +2,12 @@
 <html>
 	<head>
 		<title>Download Caddy</title>
-		{{include "/includes/head.html"}}
-		<link rel="stylesheet" href="/resources/css/download.css">
+		{{import "/includes/head.html"}}
+		{{template "head"}}
+		<link rel="stylesheet" href="/resources/css/download.css{{template "cacheBust"}}">
 		<script src="/resources/js/jquery-3.4.1.min.js"></script>
 		<script src="/resources/js/sweetalert.min.js"></script>
-		<script src="/resources/js/download.js"></script>
+		<script src="/resources/js/download.js{{template "cacheBust"}}"></script>
 	</head>
 	<body>
 		<div class="wrapper">

--- a/src/includes/account/head.html
+++ b/src/includes/account/head.html
@@ -1,5 +1,8 @@
-{{include "/includes/head.html"}}
-<link rel="stylesheet" href="/resources/css/account/common.css">
-<script src="/resources/js/jquery-3.4.1.min.js"></script>
-<script src="/resources/js/sweetalert.min.js"></script>
-<script src="/resources/js/account/common.js"></script>
+{{define "account-head"}}
+	{{import "/includes/head.html"}}
+	{{template "head"}}
+	<link rel="stylesheet" href="/resources/css/account/common.css{{template "cacheBust"}}">
+	<script src="/resources/js/jquery-3.4.1.min.js"></script>
+	<script src="/resources/js/sweetalert.min.js"></script>
+	<script src="/resources/js/account/common.js{{template "cacheBust"}}"></script>
+{{end}}

--- a/src/includes/docs/head.html
+++ b/src/includes/docs/head.html
@@ -1,10 +1,13 @@
-{{include "/includes/head.html"}}
-<link rel="stylesheet" href="/resources/css/docs.css">
-<link rel="stylesheet" href="/resources/css/chroma.css">
-{{$directives := list }}
-{{range $i, $file := (listFiles "/docs/markdown/caddyfile/directives")}}
-    {{$directives = append $directives ($file | trimSuffix ".md")}}
+{{define "docs-head"}}
+	{{import "/includes/head.html"}}
+	{{template "head"}}
+	<link rel="stylesheet" href="/resources/css/docs.css{{template "cacheBust"}}">
+	<link rel="stylesheet" href="/resources/css/chroma.css{{template "cacheBust"}}">
+	{{$directives := list }}
+	{{range $i, $file := (listFiles "/docs/markdown/caddyfile/directives")}}
+		{{$directives = append $directives ($file | trimSuffix ".md")}}
+	{{end}}
+	<script type="text/javascript">window.CaddyfileDirectives = {{$directives | toJson}};</script>
+	<script src="/resources/js/jquery-3.4.1.min.js"></script>
+	<script src="/resources/js/docs.js{{template "cacheBust"}}"></script>
 {{end}}
-<script type="text/javascript">window.CaddyfileDirectives = {{$directives | toJson}};</script>
-<script src="/resources/js/jquery-3.4.1.min.js"></script>
-<script src="/resources/js/docs.js"></script>

--- a/src/includes/head.html
+++ b/src/includes/head.html
@@ -1,12 +1,20 @@
+{{define "cacheBust" -}}
+	{{- if fileExists "/.commit-hash" -}}
+		{{- $commitHash := (include "/.commit-hash") -}}
+		{{- trim (printf "?v=%v" $commitHash) -}}
+	{{- end -}}
+{{- end}}
+
+{{define "head"}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="preconnect" href="https://BH4D9OD16A-dsn.algolia.net" crossorigin />
 
-<link rel="icon" href="/resources/images/favicon.png">
+<link rel="icon" href="/resources/images/favicon.png{{template "cacheBust"}}">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter:400,700|Maven+Pro:400,700,900|Montserrat:400,700|PT+Mono&display=swap">
-<link rel="stylesheet" href="/resources/css/common.css">
-<script src="/resources/js/common.js"></script>
+<link rel="stylesheet" href="/resources/css/common.css{{template "cacheBust"}}">
+<script src="/resources/js/common.js{{template "cacheBust"}}"></script>
 
 <!-- General metatags -->
 <meta name="author" content="Caddy Web Server">
@@ -41,3 +49,4 @@
 <!-- Alpine.js to augment markdown docs -->
 <script src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+{{end}}

--- a/src/index.html
+++ b/src/index.html
@@ -2,8 +2,9 @@
 <html>
 	<head>
 		<title>Caddy - The Ultimate Server with Automatic HTTPS</title>
-		{{include "/includes/head.html"}}
-		<link rel="stylesheet" href="/resources/css/home.css">
+		{{import "/includes/head.html"}}
+		{{template "head"}}
+		<link rel="stylesheet" href="/resources/css/home.css{{template "cacheBust"}}">
 		<meta property="og:title" content="Caddy 2 - The Ultimate Server with Automatic HTTPS">
 		<meta name="twitter:title" value="Caddy 2 - The Ultimate Server with Automatic HTTPS">
 	</head>

--- a/src/v2.html
+++ b/src/v2.html
@@ -2,10 +2,11 @@
 <html>
 	<head>
 		<title>Caddy 2</title>
-		{{include "/includes/head.html"}}
+		{{import "/includes/head.html"}}
+		{{template "head"}}
 		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Dancing+Script:wght@700&display=swap">
 		<link rel="stylesheet" href="/resources/css/asciinema-player-2.6.1.css">
-		<link rel="stylesheet" href="/resources/css/v2-landing.css">
+		<link rel="stylesheet" href="/resources/css/v2-landing.css{{template "cacheBust"}}">
 		<meta property="og:title" content="Introducing Caddy 2 - The Ultimate Server with Automatic HTTPS">
 		<meta name="twitter:title" value="Introducing Caddy 2 - The Ultimate Server with Automatic HTTPS">
 	</head>


### PR DESCRIPTION
- Switch all `head.html` to be rendered with `import` instead of `include`, to retain the `define` template stack

- Define a `cacheBust` template in the main `head.html` whose value is pulled from `src/.commit-hash` if that file exists. The file gets created on the website's server with a `post-checkout` git-hook. Its value is something like `?v=abc1234`, i.e. a query. If the file isn't there (e.g. in local dev), the template is empty string (no query).

- Use `{{template "cacheBust"}}` as a suffix to any JS/CSS asset files which are likely to change. I skipped minified ones cause they mostly had version numbers in the filename so it's redundant (if we upgrade those libs, we'll change the filename anyway).

I'm not sure if there's a better way. This is what I could get to work. I'm only dabbling in templates-land, I'm not too familiar with what's conventional. Is this fine? A `cacheBust` template is the only way I could figure out how to load the file once per request, because variables like `$cacheBust := "foo"` are not propagated across template files. 

To test this, checkout this branch, launch the website, and look at the raw HTML output to see that files don't have `?v=`. Then, create the `src/.commit-hash` file, put in `some-dumb-string`. Then refresh the website, you'll see `?v=some-dumb-string` appended to most JS/CSS files.