### PR TITLE
Fix query filter typo for uri example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/log.md
+++ b/src/docs/markdown/caddyfile/directives/log.md
@@ -277,7 +277,7 @@ Most commonly, the fields to filter would be `request>remote_ip` for the directl
 
 ##### query
 
-Marks a field to have one or more actions performed, to manipulate the query part of a URL field. Most commonly, the field to filter would be `uri`. The available actions are:
+Marks a field to have one or more actions performed, to manipulate the query part of a URL field. Most commonly, the field to filter would be `request>uri`. The available actions are:
 
 ```caddy-d
 <field> query {


### PR DESCRIPTION
A very small typo which confused me a bit when starting with caddy.
This way the doc is more consistent with other examples mentionned around.