### PR TITLE
Remove suggested static file location of /home

### DIFF
--- a/src/docs/markdown/quick-starts/static-files.md
+++ b/src/docs/markdown/quick-starts/static-files.md
@@ -70,7 +70,7 @@ You can also use another folder as the site root:
 ```caddy
 localhost
 
-root * /home/me/mysite
+root * /var/www/mysite
 file_server
 ```
 


### PR DESCRIPTION
Replaced `root * /home/me` with `root * /var/www` in the final code block of static-files.md

As explained in [this forum solution](https://caddy.community/t/cant-serve-static-files-how-to-debug-path-permissions-errors/12719/6), the systemd setting `ProtectHome` (default true) prevents Caddy from accessing files within a user's home directory, which causes unexplained 403 errors even when file system permission levels appear to be correct.

Therefore I am removing the suggestion to serve static files from `/home` and replacing it with a more common `/var/www`.