### PR TITLE
doc: type fix `http://` => `http`

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -219,7 +219,7 @@ These are examples of valid addresses:
 
 <aside class="tip">
 
-[Automatic HTTPS](/docs/automatic-https) is enabled if your site's address contains a hostname or IP address. This behavior is purely implicit, however, so it never overrides any explicit configuration. For example, if the site's address is `http://example.com`, auto-HTTPS will not activate because the scheme is explicitly `http://`.
+[Automatic HTTPS](/docs/automatic-https) is enabled if your site's address contains a hostname or IP address. This behavior is purely implicit, however, so it never overrides any explicit configuration. For example, if the site's address is `http://example.com`, auto-HTTPS will not activate because the scheme is explicitly `http`.
 
 </aside>
 


### PR DESCRIPTION
`http.request.scheme` does NOT include the `://`. It is only `http` or `https`.

For example:

```perl
    @match-cors-api-request {
        not {
            header Origin "{http.request.scheme}://{http.request.host}"
        }
        header Origin "{http.request.header.origin}"
    }
```

I think it would be best to enumerate the possible values to avoid confusion since browsers consider it to be `http:` and it is often referenced as `http://`, but is often also just `http`, etc.