### PR TITLE
docs: Add default for reverse_proxy health_timeout

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -316,7 +316,7 @@ Active health checks perform health checking in the background on a timer. To en
 
 - **health_interval** <span id="health_interval"/> is a [duration value](/docs/conventions#durations) that defines how often to perform active health checks. Default: `30s`.
 
-- **health_timeout** <span id="health_timeout"/> is a [duration value](/docs/conventions#durations) that defines how long to wait for a reply before marking the backend as down.
+- **health_timeout** <span id="health_timeout"/> is a [duration value](/docs/conventions#durations) that defines how long to wait for a reply before marking the backend as down. Default: `5s`.
 
 - **health_status** <span id="health_status"/> is the HTTP status code to expect from a healthy backend. Can be a 3-digit status code, or a status code class ending in `xx`. For example: `200` (which is the default), or `2xx`.
 


### PR DESCRIPTION
Currently, https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#active-health-checks is missing the default value for `health_timeout`. It has been added based on https://github.com/caddyserver/caddy/blob/d949caf459c3e046e6f4020dbb685c07812d5b80/modules/caddyhttp/reverseproxy/healthchecks.go#L88