### PR TITLE
build: Suggest restarting service to load custom modules

### DIFF
--- a/src/docs/markdown/build.md
+++ b/src/docs/markdown/build.md
@@ -85,6 +85,7 @@ Procedure:
 <span class="bash">sudo mv ./caddy /usr/bin/caddy.custom</span>
 <span class="bash">sudo update-alternatives --install /usr/bin/caddy caddy /usr/bin/caddy.default 10</span>
 <span class="bash">sudo update-alternatives --install /usr/bin/caddy caddy /usr/bin/caddy.custom 50</span>
+<span class="bash">sudo systemctl restart caddy</span>
 </code></pre>
 
 
@@ -92,6 +93,8 @@ Procedure:
 
 `update-alternatives` will create a symlink from the desired caddy binary to `/usr/bin/caddy`
 
+`systemctl restart caddy` will shut down the default version of the Caddy server and start the custom one.
+
 You can change between the custom and default `caddy` binaries by executing
 <pre><code class="cmd bash">update-alternatives --config caddy</code></pre>
-and following the on screen information.
+and following the on screen information, then restarting the Caddy service.


### PR DESCRIPTION
I followed these instructions on a fresh Debian 12 box, seemingly
successfully. But `systemctl reload caddy` would reject my Caddyfile
that tried to use those custom modules, logging "unknown module" errors,
even though `caddy list-modules` reported that they were installed.
After reading [a comment on `caddyserver/cache-handler`][c], I tried
running `systemctl restart caddy`, which immediately fixed the issue.

In retrospect, it makes sense that since `apt install caddy` starts the
systemd service, replacing the binary on the filesystem does nothing to
change the running server. But the instructions didn't suggest this, and
I'm used to only `reload`ing Caddy, so I didn't think of it myself.

[c]: https://github.com/caddyserver/cache-handler/issues/33#issuecomment-1234457086

wchargin-branch: custom-build-systemctl-restart
