### PR TITLE
Note that caddy fmt doesn't support heredocs

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -181,6 +181,10 @@ The closing marker can be indented, which causes every line of text to have that
 
 Additional tokens may follow the closing marker as arguments to the directive (such as in the example above, the status code `200`).
 
+<aside class="advice">
+The [`caddy fmt`](/docs/command-line#caddy-fmt) command [does not support](https://github.com/caddyserver/caddy/issues/5930#issuecomment-1797709061) heredocs.
+</aside>
+
 
 ## Global options
 

--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -182,7 +182,9 @@ The closing marker can be indented, which causes every line of text to have that
 Additional tokens may follow the closing marker as arguments to the directive (such as in the example above, the status code `200`).
 
 <aside class="advice">
+
 The [`caddy fmt`](/docs/command-line#caddy-fmt) command [does not support](https://github.com/caddyserver/caddy/issues/5930#issuecomment-1797709061) heredocs.
+
 </aside>
 
 

--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -235,7 +235,9 @@ Formats or prettifies a Caddyfile, then exits. The result is printed to stdout u
 
 
 <aside class="advice">
+
 The `caddy fmt` command [does not support](https://github.com/caddyserver/caddy/issues/5930#issuecomment-1797709061) [heredocs](/docs/caddyfile/concepts#heredocs).
+
 </aside>
 
 

--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -234,6 +234,9 @@ Formats or prettifies a Caddyfile, then exits. The result is printed to stdout u
 `--diff` causes the output to be compared against the input, and lines will be prefixed with `-` and `+` where they differ. Note that unchanges lines are prefixed with two spaces for alignment, and that this is not a valid patch format; it's just meant as a visual tool.
 
 
+<aside class="advice">
+The `caddy fmt` command [does not support](https://github.com/caddyserver/caddy/issues/5930#issuecomment-1797709061) [heredocs](/docs/caddyfile/concepts#heredocs).
+</aside>
 
 
 ### `caddy hash-password`


### PR DESCRIPTION
Fixes caddyserver/caddy#5930

I see there's a `new` branch; it would be good if this could be ported at the appropriate time.

(Edit: `advice` might be the wrong level — but that's straightforward to change.)