### PR TITLE
Testimonials: Fixed twitter post link SwiftOnSecurity

### DIFF
--- a/src/resources/testimonials.json
+++ b/src/resources/testimonials.json
@@ -182,7 +182,7 @@
 		"picture": "https://pbs.twimg.com/profile_images/1710842853134315521/LImt45Gv_400x400.jpg",
 		"role": "Computer security person",
 		"quote": "Next public server I put up, I'm just sticking Caddy on it.",
-		"link": "https://twitter.com/bwesterb/status/1708903488426512668"
+		"link": "https://twitter.com/SwiftOnSecurity/status/885264457231994880"
 	},
 	{
 		"username": "Zestyclose_Car1088",


### PR DESCRIPTION
Accidentally found a wrong link (copy and paste) on the testimonials section of the great new website.
This pull request is fixing the link to the intended twitter post.