### PR TITLE
dns_challenge_override_domain: clarify expected domain and DNS plugin support

### DIFF
--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -114,7 +114,7 @@ Keep in mind that Let's Encrypt may send you emails about your certificate neari
 
 - **dns_challenge_override_domain** <span id="dns_challenge_override_domain"/> overrides the domain to use for the DNS challenge. This is to delegate the challenge to a different domain.
 
-  You may want to use this if your primary domain's DNS provider does not have a [DNS plugin <img src="/old/resources/images/external-link.svg" class="external-link">](https://github.com/caddy-dns) available. You can instead add a `CNAME` record with subdomain `_acme-challenge` to your primary domain, pointing to a secondary domain for which you _do_ have a plugin.
+  You may want to use this if your primary domain's DNS provider does not have a [DNS plugin <img src="/old/resources/images/external-link.svg" class="external-link">](https://github.com/caddy-dns) available. You can instead add a `CNAME` record with subdomain `_acme-challenge` to your primary domain, pointing to a secondary domain for which you _do_ have a plugin. This option _does not_ require special support from the plugin.
   
   When ACME issuers try to solve the DNS challenge for your primary domain, they will then follow the `CNAME` to your secondary domain to find the `TXT` record.
 
@@ -232,7 +232,7 @@ Obtains certificates using the ACME protocol. Note that `acme` is a default issu
 
 - **dns_challenge_override_domain** <span id="dns_challenge_override_domain"/> overrides the domain to use for the DNS challenge. This is to delegate the challenge to a different domain.
 
-  You may want to use this if your primary domain's DNS provider does not have a [DNS plugin <img src="/old/resources/images/external-link.svg" class="external-link">](https://github.com/caddy-dns) available. You can instead add a `CNAME` record with subdomain `_acme-challenge` to your primary domain, pointing to a secondary domain for which you _do_ have a plugin.
+  You may want to use this if your primary domain's DNS provider does not have a [DNS plugin <img src="/old/resources/images/external-link.svg" class="external-link">](https://github.com/caddy-dns) available. You can instead add a `CNAME` record with subdomain `_acme-challenge` to your primary domain, pointing to a secondary domain for which you _do_ have a plugin. This option _does not_ require special support from the plugin.
   
   When ACME issuers try to solve the DNS challenge for your primary domain, they will then follow the `CNAME` to your secondary domain to find the `TXT` record.
 

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -118,6 +118,8 @@ Keep in mind that Let's Encrypt may send you emails about your certificate neari
   
   When ACME issuers try to solve the DNS challenge for your primary domain, they will then follow the `CNAME` to your secondary domain to find the `TXT` record.
 
+  **Note:** Use full canonical name from the CNAME record as value here - `_acme-challenge` subdomain won't be prepended automatically.
+
 - **resolvers** <span id="resolvers"/> customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones. If set here, the resolvers will propagate to all configured certificate issuers.
 
   This is typically a list of IP addresses. For example, to use [Google Public DNS <img src="/old/resources/images/external-link.svg" class="external-link">](https://developers.google.com/speed/public-dns):
@@ -233,6 +235,8 @@ Obtains certificates using the ACME protocol. Note that `acme` is a default issu
   You may want to use this if your primary domain's DNS provider does not have a [DNS plugin <img src="/old/resources/images/external-link.svg" class="external-link">](https://github.com/caddy-dns) available. You can instead add a `CNAME` record with subdomain `_acme-challenge` to your primary domain, pointing to a secondary domain for which you _do_ have a plugin.
   
   When ACME issuers try to solve the DNS challenge for your primary domain, they will then follow the `CNAME` to your secondary domain to find the `TXT` record.
+
+  **Note:** Use full canonical name from the CNAME record as value here - `_acme-challenge` subdomain won't be prepended automatically.
 
 - **resolvers** <span id="resolvers"/> customizes the DNS resolvers used when performing the DNS challenge; these take precedence over system resolvers or any default ones. If set here, the resolvers will propagate to all configured certificate issuers.
 


### PR DESCRIPTION
For context: I have a CNAME record that makes `_acme-challenge.domain1.com` point to `_acme-challenge.domain2.com`.

1. When I was searching online for how to use DNS-01 challenge delegation with Caddy, I was constantly running into pages about DuckDNS plugin's support for this feature (e.g. https://caddy.community/t/can-i-use-dns-alias-mode-to-issue-a-cert-with-caddy/11877). For some reason the `dns_challenge_override_domain` config option (added in https://github.com/caddyserver/caddy/issues/4071) didn't really pop up in my searches until today, and even then I thought I would have to patch the OVH plugin, since it wasn't logging any errors with the override domain set to `domain2.com`. It would just timeout and throw an error: `no memory of presenting a DNS record for "domain2.com" (usually OK if presenting also failed)`.

2. This post: https://caddy.community/t/global-dns-challenge-and-dns-challenge-override-domain/16773/3 was written for DuckDNS plugin's own `override_domain` option, and as such it said that `_acme-challenge` mustn't be prepended to that option's value in Caddyfile. I initially assumed this would be true for OVH plugin as well, despite not having custom override code in it.
On the other hand, this post: https://caddy.community/t/issuing-a-cert-with-the-dns-challenge-override-domain-directive-is-not-working-while-possible-to-issue-a-cert-for-the-alias-domain-itself/18477/2 made it clear to me that the domain set for Caddy's own `dns_challenge_override_domain` will be used as-is with (any?) DNS plugin.

That was pretty confusing, so I think it would be good to have it clarified in official docs.