### PR TITLE
add ids to some sections on features page

### DIFF
--- a/src/features.html
+++ b/src/features.html
@@ -439,7 +439,7 @@
 
 			<section class="diagonal up dark feature">
 				<div class="wrapper">
-					<h2>
+					<h2 id="automatic-https">
 						Automatic HTTPS
 					</h2>
 					<p>
@@ -589,7 +589,7 @@
 						</div>
 					</div>
 
-					<h3 class="purple">ACME</h3>
+					<h3 class="purple" id="automatic-https-acme">ACME</h3>
 
 					<p>
 						Caddy's ACME client is best-in-class, with higher reliability and more production experience than any other integrated ACME client available today. Caddy has been using ACME since before the public availability of Let's Encrypt, and Caddy works with any ACME-compatible CA.


### PR DESCRIPTION
There's a need to link to the "Automatic HTTPS" and "ACME" sections. I've added an "id" attribute so we can link by fragment.