### PR TITLE
remove www part from transistor domain sponsor

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -94,7 +94,7 @@
 							<a href="https://appcove.com/" target="_blank">
 								<img src="/resources/images/sponsors/appcove.png" alt="AppCove" title="AppCove" height="24">
 							</a>
-							<a href="https://www.transistor.fm" target="_blank">
+							<a href="https://transistor.fm" target="_blank">
 								<img src="/resources/images/sponsors/transistorfm.svg" alt="Transistor" title="Transistor" height="32">
 							</a>
 							<a href="https://photostructure.com/" target="_blank">


### PR DESCRIPTION
it causes ERR_SSL_UNRECOGNIZED_NAME_ALERT when you click on 'transistor' sponsor on the main page