### PR TITLE
Update install.md - Add OPNsense installation method

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -32,6 +32,7 @@ Our [official packages](https://github.com/caddyserver/dist) come only with the 
 - [Termux](#termux)
 - [Nix/Nixpkgs/NixOS](#nixnixpkgsnixos)
 - [Unikraft](#unikraft)
+- [OPNsense](#opnsense)
 
 
 ## Static binaries
@@ -220,3 +221,14 @@ Then run Caddy with Unikraft using:
 To allow non-localhost incoming connections, you need to [connect the unikernel instance to a network](https://unikraft.org/docs/cli/running#connecting-a-unikernel-instance-to-a-network).
 
 [**View the Unikraft application catalog**](https://github.com/unikraft/catalog/tree/main/examples/caddy) and [**the KraftCloud platform examples (powered by Unikraft)**](https://github.com/kraftcloud/examples/tree/main/caddy).
+
+
+
+## OPNsense
+
+_Note: This is a community-maintained installation method._
+
+<pre><code class="cmd">pkg install os-caddy</code></pre>
+
+[**View the FreeBSD caddy-custom makefile**](https://github.com/opnsense/ports/blob/master/www/caddy-custom/Makefile) and [**the os-caddy plugin source**](https://github.com/opnsense/plugins/tree/master/www/caddy)
+


### PR DESCRIPTION
I'm not sure if a more specialized implementation of Caddy is also allowed to be shown on the website. This integration offers a GUI inside the OPNsense Firewall.

The os-caddy package is the GUI component, and it depends on caddy-custom, an xcaddy built Caddy in the FreeBSD ports.

Since OPNsense runs on FreeBSD, Caddy can be used like on any other plattform (by editing the Caddyfile and not using the provided GUI if wanted). 

I think it's worth a shot to offer a quick example of this community maintained installation method, since it's a part of OPNsense ports and plugins now.