### PR TITLE
Fix prometheus.yml metrics config

### DIFF
--- a/src/docs/markdown/metrics.md
+++ b/src/docs/markdown/metrics.md
@@ -48,6 +48,7 @@ global:
 
 scrape_configs:
   - job_name: caddy
+    metrics_path: /metrics
     static_configs:
       - targets: ['localhost:2019']
 ```


### PR DESCRIPTION
Prometheus metrics require the `/metrics` path to work correctly.