### PR TITLE
Fix broken link for otel env variables

### DIFF
--- a/src/docs/markdown/caddyfile/directives/tracing.md
+++ b/src/docs/markdown/caddyfile/directives/tracing.md
@@ -29,7 +29,7 @@ tracing {
 ### Environment variables
 
 It can be configured using the environment variables defined
-by the [OpenTelemetry Environment Variable Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md).
+by the [OpenTelemetry Environment Variable Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md).
 
 For the exporter configuration details, please
 see [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/protocol/exporter.md).


### PR DESCRIPTION
The following page https://caddyserver.com/docs/caddyfile/directives/tracing directs to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md which returns a 404. 

I updated it to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)

Let me know if it would be better to reference a tagged version so it won't break in the future! 