### PR TITLE
Another example how to use log_append for reverse proxy upstream details

### DIFF
--- a/src/docs/markdown/caddyfile/directives/log_append.md
+++ b/src/docs/markdown/caddyfile/directives/log_append.md
@@ -38,7 +38,7 @@ example.com {
 }
 ```
 
-Display in the logs, which reverse proxy upstream was effectively used (either `node1:80`, `node2:80` or `node3:80`) and
+Display in the logs, which reverse proxy upstream was effectively used (either `node1`, `node2` or `node3`) and
 the time spent proxying to the upstream in milliseconds as well as how long it took the proxy upstream to write the response header:
 
 ```caddy

--- a/src/docs/markdown/caddyfile/directives/log_append.md
+++ b/src/docs/markdown/caddyfile/directives/log_append.md
@@ -48,7 +48,7 @@ example.com {
 	handle {
 		reverse_proxy node1:80 node2:80 node3:80 {
 			lb_policy random_choose 2 
-        }
+		}
 		log_append upstream-host "{http.reverse_proxy.upstream.host}"
 		log_append upstream-duration-ms "{http.reverse_proxy.upstream.duration_ms}"
 		log_append upstream-latency-ms "{http.reverse_proxy.upstream.latency_ms}"

--- a/src/docs/markdown/caddyfile/directives/log_append.md
+++ b/src/docs/markdown/caddyfile/directives/log_append.md
@@ -37,3 +37,22 @@ example.com {
 	}
 }
 ```
+
+Display in the logs, which reverse proxy upstream was effectively used (either `node1:80`, `node2:80` or `node3:80`) and
+the time spent proxying to the upstream in milliseconds as well as how long it took the proxy upstream to write the response header:
+
+```caddy
+example.com {
+	log
+
+	handle {
+		reverse_proxy node1:80 node2:80 node3:80 {
+			header_up Host {upstream_hostport}
+			lb_policy random_choose 2 
+        }
+		log_append upstream-host "{http.reverse_proxy.upstream.host}"
+		log_append upstream-duration-ms "{http.reverse_proxy.upstream.duration_ms}"
+		log_append upstream-latency-ms "{http.reverse_proxy.upstream.latency_ms}"
+	}
+}
+```

--- a/src/docs/markdown/caddyfile/directives/log_append.md
+++ b/src/docs/markdown/caddyfile/directives/log_append.md
@@ -49,9 +49,9 @@ example.com {
 		reverse_proxy node1:80 node2:80 node3:80 {
 			lb_policy random_choose 2 
 		}
-		log_append upstream-host "{http.reverse_proxy.upstream.host}"
-		log_append upstream-duration-ms "{http.reverse_proxy.upstream.duration_ms}"
-		log_append upstream-latency-ms "{http.reverse_proxy.upstream.latency_ms}"
+		log_append upstream_host {rp.upstream.host}
+		log_append upstream_duration_ms {rp.upstream.duration_ms}
+		log_append upstream_latency_ms {rp.upstream.latency_ms}
 	}
 }
 ```

--- a/src/docs/markdown/caddyfile/directives/log_append.md
+++ b/src/docs/markdown/caddyfile/directives/log_append.md
@@ -47,7 +47,6 @@ example.com {
 
 	handle {
 		reverse_proxy node1:80 node2:80 node3:80 {
-			header_up Host {upstream_hostport}
 			lb_policy random_choose 2 
         }
 		log_append upstream-host "{http.reverse_proxy.upstream.host}"


### PR DESCRIPTION
I have added one of my use-cases for `log_append` as another example. When using multiple `reverse_proxy` upstreams, it can be useful to have the upstream as well as time and latency in the logs using the placeholders from https://caddyserver.com/docs/json/apps/http/servers/routes/handle/reverse_proxy/#docs