### PR TITLE
Add keyring permissions

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -63,6 +63,7 @@ After installing, please read the [service usage instructions](/docs/running#usi
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list</span>
+<span class="bash">chmod 664 /usr/share/keyrings/caddy-stable-archive-keyring.gpg</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 
@@ -71,6 +72,7 @@ After installing, please read the [service usage instructions](/docs/running#usi
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-testing-archive-keyring.gpg</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-testing.list</span>
+<span class="bash">chmod 664 /usr/share/keyrings/caddy-stable-archive-keyring.gpg</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 


### PR DESCRIPTION
Fixes install instructions to correct file permissions on the Caddy GPG key - required; otherwise you'll get the following error:

The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ...