### PR TITLE
developer documentation for placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,13 @@ Your first time, you may be prompted for a password. This is so Caddy can serve 
 
 You can then load [https://localhost](https://localhost) (or whatever address you configured) in your browser.
 
+### Docker
+
+You can run rootless with docker with
+```
+docker stop caddy-website || true && docker rm caddy-website || true
+docker run --name caddy-website -it -p 8443:443 -v ./:/wd caddy sh -c "cd /wd && caddy run"
+```
+
+This will allow you to connect to https://localhost:8443
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -4,9 +4,9 @@ title: "Placeholder Support"
 
 # Placeholders
 
-In Caddy, placeholders are a feature of the individual plugins. They are not parsed at config time, but instead preserved, and replaced at runtime.
+In Caddy, placeholders are processed by each individual plugin themselves. They are not parsed at config time, but instead preserved and processed at runtime.
 
-This means that if you wish for your plugin to support placeholders, you must explicitly add support for it.
+This means that if you wish for your plugin to support placeholders, you must explicitly add support for them.
 
 If you are not yet familiar with placeholders, start by reading [here](/docs/conventions#placeholders)!
 
@@ -75,18 +75,18 @@ When you adapt this Caddyfile with `HOST=example caddy adapt` you will get
 
 Importantly, look at the `"body"` field in both `srv0` and `srv1`.
 
-Since `srv0` used `{$ENV}`, the special environmental variable replacement with `$` became `example`, as it is parsed during Caddyfile parse time.
+Since `srv0` used `{$HOST}`, the special environmental variable replacement with `$`, the value became `example`, as it was processed during Caddyfile parse time.
 
 Since `srv1` used `{env.HOST}`, a normal placeholder, it was parsed as its own raw string value, `{env.HOST}`
 
-This means that down the line, the handler the plugins within `srv0` and `srv1` will receive the raw values `example` and `{env.Host}` respectively in their configurations.
+Some users may immediately notice that this means it is impossible to use the `{$ENV}` syntax in a JSON config. The solution to this is to process such placeholders at Provision time, which is covered below.
 
 
-## How to Placeholders in your Plugin
+## How to use Placeholders in your Plugin
 
-#### Parse the raw Placeholder in your unmarshaler
+#### Parse the raw Placeholder value in your unmarshaler
 
-Placeholders should be parsed as their raw values when parsing the Cazddyfile, just like any other string value
+Placeholders should be parsed as their raw values when parsing the Cazddyfile, just like any other string value.
 
 ```go
 func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -115,7 +115,7 @@ func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp
 
 #### Alternatively, resolve the Placeholder during Provision
 
-If you only use global placeholders, like `env`, then you may initialize a global replacer at provision time, and use it to replace such values.
+If you only use global placeholders, like `env`, then you may initialize a global replacer at provision time, and use it to replace such values. This also allows users of config file formats other than Caddyfile to use environmental variables.
 
 ```go
 func (g *Gizmo) Provision(ctx caddy.Context) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -12,7 +12,7 @@ If you are not yet familiar with placeholders, start by reading [here](/docs/con
 
 ## Placeholder Internals
 
-Internally, placeholders are simply a string in format `{foo.bar}` used as valid configuration values, which is later parsed at runtime.
+Placeholders are a string in the format `{foo.bar}` used as dynamic configuration values, which is later evaluated at runtime.
 
 Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts#environment-variables), they just happen to share the `{}` syntax.
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -86,7 +86,9 @@ Some users may immediately notice that this means it is impossible to use the `{
 
 #### Parse the raw placeholder value in your unmarshaler
 
-Placeholders should be parsed as their raw values when parsing the Cazddyfile, just like any other string value.
+Placeholders are not evaluated at Caddyfile parse time, and should be preserved for later use. They are used as their raw string values.
+
+In other words, parsing a placeholder is no different from parsing any other string.
 
 ```go
 func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -98,7 +100,7 @@ func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 ```
 
-#### Resolve the placeholder during Match or Serve
+#### Evaluate the placeholder during Match or Serve
 
 In order to now correctly read our `g.Name` placeholder in a plugin matcher or middleware, we must extract the replacer from the context and use that replacer on our saved placeholder string.
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -18,7 +18,7 @@ Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulat
 
 It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`.
 
-As an example, see the following caddyfile:
+As an example, see the following Caddyfile:
 ```caddyfile
 :8080 {
   respond {$HOST} 200

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -21,7 +21,7 @@ This is because these are not placeholders, but Caddyfile-specific [environmenta
 It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
 
 As an example, see the following caddyfile:
-```
+```caddyfile
 :8080 {
   respond {$HOST} 200
 }
@@ -32,7 +32,7 @@ As an example, see the following caddyfile:
 ```
 
 When you adapt this Caddyfile with `HOST=example caddy adapt` you will get
-```
+```json
 {
   "apps": {
     "http": {
@@ -83,9 +83,9 @@ Since `srv1` used `{env.HOST}`, a standard placeholder, it was parsed as a norma
 
 This means that down the line, the handler plugins will receive both `example` and `{env.Host}` respectively in their configurations.
 
-## Using Placeholders in your Plugin
+## How to Placeholders in your Plugin
 
-#### How to parse Placeholders in your Unmarshaler
+#### Parse the raw Placeholder in your unmarshaler
 
 Placeholders should be parsed as their raw values when parsing caddyfiles, just like any other string value
 
@@ -99,7 +99,7 @@ func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 ```
 
-#### How to resolve Placeholders during Serve or Match
+#### Resolve the Placeholder during Match or Serve
 
 In order to now correctly read our `g.Name` placeholder, in a plugin matcher or middleware, we must extract the replacer from the context, and use that replacer on our saved placeholder string.
 
@@ -114,7 +114,7 @@ func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp
 }
 ```
 
-#### How to resolve Placeholders at Provision time
+#### Alternatively, resolve the Placeholder during Provision
 
 If you only use global placeholders, like `env`, then you may initialize a global replacer at provision time, and use it to replace such values.
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -100,7 +100,7 @@ func (g *Gizmo) Provision(ctx caddy.Context) error {
 }
 ```
 
-Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer not only has access global placeholders, but also http placeholders such as `{http.request.uri}`
+Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer not only has access to global placeholders, but also http placeholders such as `{http.request.uri}`
 
 ```go
 func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -100,7 +100,9 @@ func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 #### Resolve the placeholder during Match or Serve
 
-In order to now correctly read our `g.Name` placeholder, in a plugin matcher or middleware, we must extract the replacer from the context, and use that replacer on our saved placeholder string.
+In order to now correctly read our `g.Name` placeholder in a plugin matcher or middleware, we must extract the replacer from the context and use that replacer on our saved placeholder string.
+
+This gives us a string with all valid replacements done, which we can then use in whichever way we want. In the example, we write those bytes to output
 
 ```go
 func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -84,7 +84,7 @@ Some users may immediately notice that this means it is impossible to use the `{
 
 ## Implementing placeholder support
 
-You should not process placeholders when ummarshaling your Caddyfile. Instead, unmarshal the placeholders as strings in your configuration and evaluate them during either your module's execution or `Provision()` using a `caddy.Replacer`.
+You should not process placeholders when ummarshaling your Caddyfile. Instead, unmarshal the placeholders as strings in your configuration and evaluate them during either your module's execution (e.g. `ServeHTTP()` for HTTP handlers, `Match()` for matchers, etc.) or in the `Provision()` step, using a `caddy.Replacer`.
 
 
 ### Examples

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -2,13 +2,21 @@
 title: "Placeholder Support"
 ---
 
-# Placeholder Parsing Rules
+# Placeholders
 
-Support for placeholders which do not start with a dollar sign (e.g. `{env.HOST}`) must be handled by the individual plugin, and will not be handled by the Caddyfile parser.
+In Caddy, placeholders are a feature of the individual plugins, that is, they are not parsed at config time, but instead preserved, and replaced at runtime.
+
+This means that if you wish for your plugin to support placeholders, you must explicitly add support for it.
+
+## Placeholder Parsing Rules & Gotchas
+
+Support for any placeholders which do not start with a dollar sign (e.g. `{env.HOST}`) must be handled by the individual plugin, and will not be handled by the Caddyfile parser.
 
 If you wish to use placeholders in your Caddy plugin, you must accept such placeholders as valid configuration values, and parse them at runtime
 
-Placeholders which do start with a dollar sign (`{$HOST}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin
+Placeholders which do start with a dollar sign (`{$HOST}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. These are technically not placeholders, but config-time env var substitution, they just happen to share the `{}` syntax. our
+
+It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
 
 As an example, see the following caddyfile:
 ```
@@ -71,12 +79,13 @@ Since `srv0` used `{$ENV}`, the special environmental variable placeholder with 
 
 Since `srv1` used `{env.HOST}`, a standard placeholder, it was parsed as a normal string value for "body" field of the respond directive's config.
 
+This means that down the line, the handler plugins will receive both `example` and `{env.Host}` respectively in their configurations.
+
 ## Using Placeholders in your Plugin
 
-#### Parsing Placeholders in your Unmarshaler
+#### How to parse Placeholders in your Unmarshaler
 
 Placeholders should be parsed as their raw values when parsing caddyfiles, just like any other string value
-
 
 ```go
 func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -85,12 +94,12 @@ func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		// not enough args
 		return d.ArgErr()
 	}
+}
 ```
 
+#### How to resolve Placeholders during Serve or Match
 
-#### Resolving Placeholders at Match/Serve time
-
-In order to correctly read our `g.Name` placeholder, in a plugin matcher or middleware, we must extract the replacer from the context, and use that replacer on our saved placeholder string.
+In order to now correctly read our `g.Name` placeholder, in a plugin matcher or middleware, we must extract the replacer from the context, and use that replacer on our saved placeholder string.
 
 ```go
 func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
@@ -103,9 +112,9 @@ func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp
 }
 ```
 
-#### Resolving Placeholers at Provision time
+#### How to resolve Placeholders at Provision time
 
-If you only use global placeholders, like `env`, then you may also use the replacer at provision time
+If you only use global placeholders, like `env`, then you may initialize a global replacer at provision time, and use it to replace such values.
 
 ```go
 func (g *Gizmo) Provision(ctx caddy.Context) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -14,7 +14,7 @@ If you are not yet familiar with placeholders, start by reading [here](/docs/con
 
 Internally, placeholders are simply a string in format `{foo.bar}` used as valid configuration values, which is later parsed at runtime.
 
-Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts#environmental-variables), they just happen to share the `{}` syntax.
+Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts#environment-variables), they just happen to share the `{}` syntax.
 
 It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -82,9 +82,9 @@ Since `srv1` used `{env.HOST}`, a normal placeholder, it was parsed as its own r
 Some users may immediately notice that this means it is impossible to use the `{$ENV}` syntax in a JSON config. The solution to this is to process such placeholders at Provision time, which is covered below.
 
 
-## How to use Placeholders in your Plugin
+## How to use placeholders in your plugin
 
-#### Parse the raw Placeholder value in your unmarshaler
+#### Parse the raw placeholder value in your unmarshaler
 
 Placeholders should be parsed as their raw values when parsing the Cazddyfile, just like any other string value.
 
@@ -98,7 +98,7 @@ func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 ```
 
-#### Resolve the Placeholder during Match or Serve
+#### Resolve the placeholder during Match or Serve
 
 In order to now correctly read our `g.Name` placeholder, in a plugin matcher or middleware, we must extract the replacer from the context, and use that replacer on our saved placeholder string.
 
@@ -113,7 +113,7 @@ func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp
 }
 ```
 
-#### Alternatively, resolve the Placeholder during Provision
+#### Alternatively, resolve the placeholder during Provision
 
 If you only use global placeholders, like `env`, then you may initialize a global replacer at provision time, and use it to replace such values. This also allows users of config file formats other than Caddyfile to use environmental variables.
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -1,0 +1,126 @@
+---
+title: "Placeholder Support"
+---
+
+# Placeholder Parsing Rules
+
+Support for placeholders which do not start with a dollar sign (e.g. `{env.HOST}`) must be handled by the individual plugin, and will not be handled by the Caddyfile parser.
+
+If you wish to use placeholders in your Caddy plugin, you must accept such placeholders as valid configuration values, and parse them at runtime
+
+Placeholders which do start with a dollar sign (`{$HOST}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin
+
+As an example, see the following caddyfile:
+```
+:8080 {
+  respond {$HOST} 200
+}
+
+:8081 {
+  respond {env.HOST} 200
+}
+```
+
+When you adapt this Caddyfile with `HOST=example caddy adapt` you will get
+```
+{
+  "apps": {
+    "http": {
+      "servers": {
+        "srv0": {
+          "listen": [
+            ":8080"
+          ],
+          "routes": [
+            {
+              "handle": [
+                {
+                  "body": "example",
+                  "handler": "static_response",
+                  "status_code": 200
+                }
+              ]
+            }
+          ]
+        },
+        "srv1": {
+          "listen": [
+            ":8081"
+          ],
+          "routes": [
+            {
+              "handle": [
+                {
+                  "body": "{env.HOST}",
+                  "handler": "static_response",
+                  "status_code": 200
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Importantly, look at the `"body"` field in both `srv0` and `srv1`.
+
+Since `srv0` used `{$ENV}`, the special environmental variable placeholder with `$`, as it is parsed during Caddyfile parse time.
+
+Since `srv1` used `{env.HOST}`, a standard placeholder, it was parsed as a normal string value for "body" field of the respond directive's config.
+
+## Using Placeholders in your Plugin
+
+#### Parsing Placeholders in your Unmarshaler
+
+Placeholders should be parsed as their raw values when parsing caddyfiles, just like any other string value
+
+
+```go
+func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	d.Next()
+	if !d.Args(&g.Name) {
+		// not enough args
+		return d.ArgErr()
+	}
+```
+
+
+#### Resolving Placeholders at Match/Serve time
+
+In order to correctly read our `g.Name` placeholder, in a plugin matcher or middleware, we must extract the replacer from the context, and use that replacer on our saved placeholder string.
+
+```go
+func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	_, err := w.Write([]byte(repl.ReplaceAll(g.Name,"")))
+	if err != nil {
+		return err
+	}
+	return next.ServeHTTP(w, r)
+}
+```
+
+#### Resolving Placeholers at Provision time
+
+If you only use global placeholders, like `env`, then you may also use the replacer at provision time
+
+```go
+func (g *Gizmo) Provision(ctx caddy.Context) error {
+	repl := caddy.NewReplacer()
+	g.Name = repl.ReplaceAll(g.Name,"")
+	return nil
+}
+
+
+func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
+	// in this case, you don't need to replace at serve-time anymore
+	_, err := w.Write([]byte(g.Name))
+	if err != nil {
+		return err
+	}
+	return next.ServeHTTP(w, r)
+}
+```

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -4,17 +4,15 @@ title: "Placeholder Support"
 
 # Placeholders
 
-In Caddy, placeholders are a feature of the individual plugins, that is, they are not parsed at config time, but instead preserved, and replaced at runtime.
+In Caddy, placeholders are a feature of the individual plugins. They are not parsed at config time, but instead preserved, and replaced at runtime.
 
 This means that if you wish for your plugin to support placeholders, you must explicitly add support for it.
 
 ## Placeholder Parsing Rules & Gotchas
 
-Support for any placeholders which do not start with a dollar sign (e.g. `{env.HOST}`) must be handled by the individual plugin, and will not be handled by the Caddyfile parser.
+If you wish to use placeholders in your Caddy plugin, you must accept placeholders strings, informat `{foo}` as valid configuration values, and parse them at runtime
 
-If you wish to use placeholders in your Caddy plugin, you must accept such placeholders as valid configuration values, and parse them at runtime
-
-Placeholders which do start with a dollar sign (`{$HOST}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. These are technically not placeholders, but config-time env var substitution, they just happen to share the `{}` syntax. our
+However, Placeholders-like strings which do start with a dollar sign (`{$foo}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. These are technically not placeholders, but config-time env-var substitution, they just happen to share the `{}` syntax.
 
 It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -4,7 +4,7 @@ title: "Placeholder Support"
 
 # Placeholders
 
-In Caddy, placeholders are processed by each individual plugin themselves. They are not parsed at config time, but instead preserved and processed at runtime.
+In Caddy, placeholders are processed by each individual plugin as needed; they do not automatically work everywhere.
 
 This means that if you wish for your plugin to support placeholders, you must explicitly add support for them.
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -89,8 +89,7 @@ You should not process placeholders when ummarshaling your Caddyfile. Instead, u
 
 ### Examples
 
-
-In this example, we are using a newly constructed replacer to process placeholders. It only has access to global placeholders such as `{env.HOST}`.
+In this example, we are using a newly constructed replacer to process placeholders. It has access to [global placeholders](/docs/conventions#placeholders) such as `{env.HOST}`, but NOT request placeholder such as `{http.request.uri}`
 
 ```go
 func (g *Gizmo) Provision(ctx caddy.Context) error {
@@ -100,7 +99,7 @@ func (g *Gizmo) Provision(ctx caddy.Context) error {
 }
 ```
 
-Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer not only has access to global placeholders, but also http placeholders such as `{http.request.uri}`.
+Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer not only has access to global placeholders, but also request placeholders such as `{http.request.uri}`.
 
 ```go
 func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -14,7 +14,7 @@ If you are not yet familiar with placeholders, start by reading [here](/docs/con
 
 Internally, placeholders are simply a string in format `{foo.bar}` used as valid configuration values, which is later parsed at runtime.
 
-Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts/#environmental-variables), they just happen to share the `{}` syntax.
+Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts#environmental-variables), they just happen to share the `{}` syntax.
 
 It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -16,7 +16,7 @@ Placeholders are a string in the format `{foo.bar}` used as dynamic configuratio
 
 Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts#environment-variables), they just happen to share the `{}` syntax.
 
-It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
+It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`.
 
 As an example, see the following caddyfile:
 ```caddyfile

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -100,7 +100,7 @@ func (g *Gizmo) Provision(ctx caddy.Context) error {
 }
 ```
 
-Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer not only has access to global placeholders, but also http placeholders such as `{http.request.uri}`
+Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer not only has access to global placeholders, but also http placeholders such as `{http.request.uri}`.
 
 ```go
 func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -10,13 +10,11 @@ This means that if you wish for your plugin to support placeholders, you must ex
 
 If you are not yet familiar with placeholders, start by reading [here](/docs/conventions#placeholders)!
 
-## Placeholder Parsing Rules & Gotchas
+## Placeholder Internals
 
-If you wish to use placeholders in your Caddy plugin, you must accept placeholders strings, in format `{foo}` as valid configuration values, and parse them at runtime
+Internally, placeholders are simply a string in format `{foo.bar}` used as valid configuration values, which is later parsed at runtime.
 
-Placeholders-like strings which start with a dollar sign (`{$foo}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin.
-
-This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts/#environmental-variables), they just happen to share the `{}` syntax.
+Placeholders-like strings which start with a dollar sign (`{$FOO}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts/#environmental-variables), they just happen to share the `{}` syntax.
 
 It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
 
@@ -77,17 +75,18 @@ When you adapt this Caddyfile with `HOST=example caddy adapt` you will get
 
 Importantly, look at the `"body"` field in both `srv0` and `srv1`.
 
-Since `srv0` used `{$ENV}`, the special environmental variable placeholder with `$`, as it is parsed during Caddyfile parse time.
+Since `srv0` used `{$ENV}`, the special environmental variable replacement with `$` became `example`, as it is parsed during Caddyfile parse time.
 
-Since `srv1` used `{env.HOST}`, a standard placeholder, it was parsed as a normal string value for "body" field of the respond directive's config.
+Since `srv1` used `{env.HOST}`, a normal placeholder, it was parsed as its own raw string value, `{env.HOST}`
 
-This means that down the line, the handler plugins will receive both `example` and `{env.Host}` respectively in their configurations.
+This means that down the line, the handler the plugins within `srv0` and `srv1` will receive the raw values `example` and `{env.Host}` respectively in their configurations.
+
 
 ## How to Placeholders in your Plugin
 
 #### Parse the raw Placeholder in your unmarshaler
 
-Placeholders should be parsed as their raw values when parsing caddyfiles, just like any other string value
+Placeholders should be parsed as their raw values when parsing the Cazddyfile, just like any other string value
 
 ```go
 func (g *Gizmo) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -90,7 +90,7 @@ You should not process placeholders when ummarshaling your Caddyfile. Instead, u
 ### Examples
 
 
-In this example, we are using a newly constructed replacer to process placeholders. It has access to placeholders such as `{env.HOST}`, but NOT `{http.request.uri}`
+In this example, we are using a newly constructed replacer to process placeholders. It only has has access to global placeholders such as `{env.HOST}`.
 
 ```go
 func (g *Gizmo) Provision(ctx caddy.Context) error {
@@ -100,7 +100,7 @@ func (g *Gizmo) Provision(ctx caddy.Context) error {
 }
 ```
 
-Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer has access to http placeholers, such as `{http.request.uri}`
+Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer has access to both global placeholders, but also http placeholders, such as `{http.request.uri}`
 
 ```go
 func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -8,11 +8,15 @@ In Caddy, placeholders are a feature of the individual plugins. They are not par
 
 This means that if you wish for your plugin to support placeholders, you must explicitly add support for it.
 
+If you are not yet familiar with placeholders, start by reading [here](/docs/conventions#placeholders)!
+
 ## Placeholder Parsing Rules & Gotchas
 
-If you wish to use placeholders in your Caddy plugin, you must accept placeholders strings, informat `{foo}` as valid configuration values, and parse them at runtime
+If you wish to use placeholders in your Caddy plugin, you must accept placeholders strings, in format `{foo}` as valid configuration values, and parse them at runtime
 
-However, Placeholders-like strings which do start with a dollar sign (`{$foo}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin. These are technically not placeholders, but config-time env-var substitution, they just happen to share the `{}` syntax.
+Placeholders-like strings which start with a dollar sign (`{$foo}`), are evaulated at Caddyfile parse time, and do not need to be dealt with by your plugin.
+
+This is because these are not placeholders, but Caddyfile-specific [environmental variable substitution](/docs/caddyfile/concepts/#environmental-variables), they just happen to share the `{}` syntax.
 
 It is therefore important to understand that `{env.HOST}` is inherently different from something like `{$HOST}`
 

--- a/src/docs/markdown/extending-caddy/placeholders.md
+++ b/src/docs/markdown/extending-caddy/placeholders.md
@@ -90,7 +90,7 @@ You should not process placeholders when ummarshaling your Caddyfile. Instead, u
 ### Examples
 
 
-In this example, we are using a newly constructed replacer to process placeholders. It only has has access to global placeholders such as `{env.HOST}`.
+In this example, we are using a newly constructed replacer to process placeholders. It only has access to global placeholders such as `{env.HOST}`.
 
 ```go
 func (g *Gizmo) Provision(ctx caddy.Context) error {
@@ -100,7 +100,7 @@ func (g *Gizmo) Provision(ctx caddy.Context) error {
 }
 ```
 
-Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer has access to both global placeholders, but also http placeholders, such as `{http.request.uri}`
+Here, we extract a replacer out of the `context.Context` inside the `*http.Request`. This replacer not only has access global placeholders, but also http placeholders such as `{http.request.uri}`
 
 ```go
 func (g *Gizmo) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {

--- a/src/old/includes/docs/nav.html
+++ b/src/old/includes/docs/nav.html
@@ -38,7 +38,7 @@
 		<li><a href="/docs/modules/">Modules</a></li>
 		<li><a href="/docs/json/">JSON Config Structure</a></li>
 		<li><a href="/docs/automatic-https">Automatic HTTPS</a></li>
-		
+
 		<li class="heading">Articles</li>
 		<li><a href="/docs/architecture">Caddy Architecture</a></li>
 		<li><a href="/docs/conventions">Conventions</a></li>
@@ -56,6 +56,7 @@
 			<ul>
 				<li><a href="/docs/extending-caddy/caddyfile">Caddyfile Support</a></li>
 				<li><a href="/docs/extending-caddy/config-adapters">Config Adapters</a></li>
+				<li><a href="/docs/extending-caddy/placeholders">Placeholders</a></li>
 			</ul>
 		</li>
 		<li><a href="/docs/extending-caddy/namespaces">Module Namespaces</a></li>


### PR DESCRIPTION
also adds a docker command to the readme that might help people working with this repo

i run caddy already locally, so it's a bit of a pain to have to disable admin. (also i cant bind to 80/443 without root)



hosting it here
https://caddy-website.put.gay/docs/extending-caddy/placeholders