### PR TITLE
docs: Update ZeroSSL issuer for v2.8

### DIFF
--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -359,22 +359,21 @@ Obtains certificates using the ACME protocol. Note that `acme` is a default issu
 
 	- **any_common_name** <span id="any_common_name"/> is a list of one or more common names; Caddy will choose the first chain that has an issuer that matches with at least one of the specified common names.
 
+##### ZeroSSL
+
+Caddy will implicitly use [ZeroSSL's ACME endpoint](https://zerossl.com/documentation/acme/) (and generate EAB credentials) if you specify the the [`email` global option](/docs/caddyfile/options#email).
+
+To provide your own EAB credentials for ZeroSSL, specify the `dir` and `eab` options.
 
 #### zerossl
 
-Obtains certificates using the ACME protocol, specifically with ZeroSSL. Note that `zerossl` is a default issuer, so configuring it explicitly is usually unnecessary.
+Obtains certificates using the ZeroSSL API.
 
 ```caddy-d
-... zerossl [<api_key>] {
+... zerossl <api_key> {
 	...
 }
 ```
-
-The syntax for `zerossl` is exactly the same as for [`acme`](#acme), except that its name is `zerossl` and it can optionally take your ZeroSSL API key.
-
-Its functionality is also the same, except that it will use ZeroSSL's directory by default and it can automatically negotiate EAB credentials (whereas with the `acme` issuer, you have to manually provide EAB credentials and set the directory endpoint).
-
-When explicitly configuring `zerossl`, configuring an `email` is required so that your certificates can appear in your ZeroSSL dashboard.
 
 #### internal
 

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -359,15 +359,17 @@ Obtains certificates using the ACME protocol. Note that `acme` is a default issu
 
 	- **any_common_name** <span id="any_common_name"/> is a list of one or more common names; Caddy will choose the first chain that has an issuer that matches with at least one of the specified common names.
 
-##### ZeroSSL
+<aside class="tip">
 
-Caddy will implicitly use [ZeroSSL's ACME endpoint](https://zerossl.com/documentation/acme/) (and generate EAB credentials) if you specify the the [`email` global option](/docs/caddyfile/options#email).
+The `acme` issuer module will implicitly use [ZeroSSL's ACME endpoint](https://zerossl.com/documentation/acme/) (and generate EAB credentials) if you specify the the [`email` global option](/docs/caddyfile/options#email).
 
 To provide your own EAB credentials for ZeroSSL, specify the `dir` and `eab` options.
 
+</aside>
+
 #### zerossl
 
-Obtains certificates using the ZeroSSL API.
+Obtains certificates using the [ZeroSSL API](https://zerossl.com/documentation/api/).
 
 ```caddy-d
 ... zerossl <api_key> {

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -373,9 +373,17 @@ Obtains certificates using the [ZeroSSL API](https://zerossl.com/documentation/a
 
 ```caddy-d
 ... zerossl <api_key> {
-	...
+	validity_days       <days>
+	alt_http_port       <port>
+	dns                 <provider_name> [<options>]
+	propagation_delay   <duration>
+	propagation_timeout <duration>
+	resolvers           <dns_servers...>
+	dns_ttl             <duration>
 }
 ```
+
+Fields for the `zerossl` issuer module share the syntax of those in common with the [`acme` issuer module](#acme).
 
 #### internal
 


### PR DESCRIPTION
Addresses the changes in caddyserver/caddy#6229 to the best of my understanding.

Particularly, marks the API key for the ZeroSSL issuer as required.

Documentation for the fields previously denoted to be inherited by `...` should still be provided, but I am not familiar with those.