### PR TITLE
use backticks instead of nested quotes in template example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/templates.md
+++ b/src/docs/markdown/caddyfile/directives/templates.md
@@ -54,6 +54,6 @@ To serve a simple static response using a template, make sure to set `Content-Ty
 example.com {
 	header Content-Type text/plain
 	templates
-	respond "Current year is: {{printf "{{"}}now | date "2006"{{printf "}}"}}"
+	respond `Current year is: {{printf "{{"}}now | date "2006"{{printf "}}"}}`
 }
 ```


### PR DESCRIPTION
When running the example for a hardcoded template response, the nested quotes yield a caddy config that does not correctly handle the template.

This example:

```
example.com {
	header Content-Type text/plain
	templates
	respond `Current year is: {{now | date "2006"}}`
}
```

results in the below

```
        "handle": [
        {
          "handler": "subroute",
          "routes": [
            {
              "handle": [
                {
                  "handler": "headers",
                  "response": {
                    "set": {
                      "Content-Type": [
                        "text/plain"
                      ]
                    }
                  }
                },
                {
                  "handler": "templates"
                },
                {
                  "body": "Current year is {{now | date ",
                  "handler": "static_response",
                  "status_code": "2006\"}}\""
                }
              ]
            }
          ]
        }
      ],
```

By replacing the outer quotes with backticks, the template is parsed as expected.
