### PR TITLE
Finish documenting Caddy 2.8.0 features

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 end_of_line = lf
 insert_final_newline = true

--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -347,6 +347,7 @@ You can use any [Caddy placeholders](/docs/conventions#placeholders) in the Cadd
 | `{remote_port}` | `{http.request.remote.port}`      |
 | `{remote}`      | `{http.request.remote}`           |
 | `{rp.*}`        | `{http.reverse_proxy.*}`          |
+| `{resp.*}`      | `{http.intercept.*}`              |
 | `{scheme}`      | `{http.request.scheme}`           |
 | `{tls_cipher}`  | `{http.request.tls.cipher_suite}` |
 | `{tls_client_certificate_der_base64}` | `{http.request.tls.client.certificate_der_base64}` |

--- a/src/docs/markdown/caddyfile/directives.md
+++ b/src/docs/markdown/caddyfile/directives.md
@@ -55,10 +55,12 @@ Directive | Description
 **[handle_path](/docs/caddyfile/directives/handle_path)** | Like handle, but strips path prefix
 **[header](/docs/caddyfile/directives/header)** | Sets or removes response headers
 **[import](/docs/caddyfile/directives/import)** | Include snippets or files
+**[intercept](/docs/caddyfile/directives/intercept)** | Intercept responses written by other handlers
 **[invoke](/docs/caddyfile/directives/invoke)** | Invoke a named route
 **[log](/docs/caddyfile/directives/log)** | Enables access/request logging
 **[log_append](/docs/caddyfile/directives/log_append)** | Append a field to the access log
 **[log_skip](/docs/caddyfile/directives/log_skip)** | Skip access logging for matched requests
+**[log_name](/docs/caddyfile/directives/log_name)** | Override the logger name(s) to write to
 **[map](/docs/caddyfile/directives/map)** | Maps an input value to one or more outputs
 **[method](/docs/caddyfile/directives/method)** | Change the HTTP method internally
 **[metrics](/docs/caddyfile/directives/metrics)** | Configures the Prometheus metrics exposition endpoint
@@ -126,6 +128,7 @@ fs
 root
 log_append
 log_skip
+log_name
 
 header
 copy_response_headers # only in reverse_proxy's handle_response block
@@ -145,6 +148,7 @@ forward_auth
 request_header
 encode
 push
+intercept
 templates
 
 # special routing & dispatching directives

--- a/src/docs/markdown/caddyfile/directives/encode.md
+++ b/src/docs/markdown/caddyfile/directives/encode.md
@@ -6,6 +6,12 @@ title: encode (Caddyfile directive)
 window.$(function() {
 	// We'll add links to all the subdirectives if a matching anchor tag is found on the page.
 	addLinksToSubdirectives();
+
+	// Response matchers
+	window.$('pre.chroma .k:contains("status")')
+		.html('<a href="/docs/caddyfile/response-matchers#status" style="color: inherit;" title="Response matcher">status</a>')
+	window.$('pre.chroma .k:contains("header")')
+		.html('<a href="/docs/caddyfile/response-matchers#header" style="color: inherit;" title="Response matcher">header</a>')
 });
 </script>
 
@@ -23,9 +29,6 @@ encode [<matcher>] <formats...> {
 	
 	minimum_length <length>
 
-	# response matcher single line syntax
-	match [header <field> [<value>]] | [status <code...>]
-	# or response matcher block for multiple conditions
 	match {
 		status <code...>
 		header <field> [<value>]
@@ -41,7 +44,7 @@ encode [<matcher>] <formats...> {
 
 - **minimum_length** <span id="minimum_length"/> the minimum number of bytes a response should have to be encoded (default: 512).
 
-- **match** <span id="match"/> is a [response matcher](#response-matcher). Only matching responses are encoded. The default looks like this:
+- **match** <span id="match"/> is a [response matcher](/docs/caddyfile/response-matchers). Only matching responses are encoded. The default looks like this:
 
   ```caddy-d
   match {
@@ -80,27 +83,6 @@ encode [<matcher>] <formats...> {
   	header Content-Type text/*
   }
   ```
-
-
-## Response matcher
-
-**Response matchers** can be used to filter (or classify) responses by specific criteria.
-
-
-### status
-
-```caddy-d
-status <code...>
-```
-
-By HTTP status code.
-
-- **&lt;code...&gt;** is a list of HTTP status codes. Special cases are `2xx`, `3xx`, ... which match against all status codes in the range of 200-299, 300-399, ... respectively
-
-
-### header
-
-See the [header](/docs/caddyfile/matchers#header) request matcher for the supported syntax.
 
 
 ## Examples

--- a/src/docs/markdown/caddyfile/directives/file_server.md
+++ b/src/docs/markdown/caddyfile/directives/file_server.md
@@ -24,6 +24,8 @@ Most often, the `file_server` directive is paired with the [`root`](root) direct
 
 When errors occur (e.g. file not found `404`, permission denied `403`), the error routes will be invoked. Use the [`handle_errors`](handle_errors) directive to define error routes, and display custom error pages.
 
+When using `browse`, the default output is produced by the the HTML template. Clients may request the directory listing as either JSON or plaintext, by using the `Accept: application/json` or `Accept: text/plain` headers respectively. The JSON output can be useful for scripting, and the plaintext output can be useful for human terminal usage.
+
 
 ## Syntax
 

--- a/src/docs/markdown/caddyfile/directives/header.md
+++ b/src/docs/markdown/caddyfile/directives/header.md
@@ -56,13 +56,13 @@ header [<matcher>] [[+|-|?|>]<field> [<value>|<find>] [<replace>]] {
 
 - **&lt;find&gt;** is the substring or regular expression to search for.
 
-- **&lt;replace&gt;** is the replacement value; required if performing a search-and-replace.
+- **&lt;replace&gt;** is the replacement value; required if performing a search-and-replace. Use `$1` or `$2` and so on to reference capture groups from the search pattern. If the replacement value is `""`, then the matching text is removed from the value. See the [Go documentation](https://golang.org/pkg/regexp/#Regexp.Expand) for details.
 
 - **defer** will force the header operations to be deferred until the response is being written out to the client. This is automatically enabled if any of the header fields are being deleted with `-`, when setting a default value with `?`, or when having used the `>` prefix.
 
 For multiple header manipulations, you can open a block and specify one manipulation per line in the same way.
 
-When using the `?` prefix to set a default header value, it is automatically separated into its own `header` handler, if it was in a `header` block with multiple header operations. [Under the hood](/docs/modules/http.handlers.headers#response/require), using `?` configures a response matcher which applies to the directive's entire handler, which only applies the header operations (like `defer`), but only if the field is not yet set.
+When using the `?` prefix to set a default header value, it is automatically separated into its own `header` handler, if it was in a `header` block with multiple header operations. [Under the hood](/docs/modules/http.handlers.headers#response/require), using `?` configures a [response matcher](/docs/caddyfile/response-matchers) which applies to the directive's entire handler, which only applies the header operations (like `defer`), but only if the field is not yet set.
 
 
 ## Examples

--- a/src/docs/markdown/caddyfile/directives/intercept.md
+++ b/src/docs/markdown/caddyfile/directives/intercept.md
@@ -1,0 +1,93 @@
+---
+title: intercept (Caddyfile directive)
+---
+
+<script>
+window.$(function() {
+	// Fix response matchers to render with the right color,
+	// and link to response matchers section
+	window.$('pre.chroma .k:contains("@")')
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			let url = '#' + item.innerText.replace(/_/g, "-");
+			window.$(item).addClass('nd').removeClass('k')
+			window.$(item).html(`<a href="#response-matcher" style="color: inherit;" title="Response matcher">${text}</a>`);
+		});
+
+	// Response matchers
+	window.$('pre.chroma .nd:contains("@name")').first().slice(0, 3)
+		.wrapAll('<span class="nd">').parent()
+		.html('<a href="/docs/caddyfile/response-matchers" style="color: inherit;">@name</a>')
+	window.$('pre.chroma .k:contains("replace_status")').first().next()
+		.html('<a href="/docs/caddyfile/response-matchers" style="color: inherit;" title="Response matcher">[&lt;matcher&gt;]</a>')
+	window.$('pre.chroma .k:contains("handle_response")').first().next()
+		.html('<a href="/docs/caddyfile/response-matchers" style="color: inherit;" title="Response matcher">[&lt;matcher&gt;]</a>')
+	window.$('pre.chroma .k')
+		.filter((i, el) => el.innerText === 'status')
+		.html('<a href="/docs/caddyfile/response-matchers#status" style="color: inherit;">status</a>')
+	window.$('pre.chroma .k:contains("header")').first()
+		.html('<a href="/docs/caddyfile/response-matchers#header" style="color: inherit;">header</a>')
+
+	// We'll add links to all the subdirectives if a matching anchor tag is found on the page.
+	addLinksToSubdirectives();
+});
+</script>
+
+# intercept
+
+A generalized abstraction of the [response interception](reverse_proxy#intercepting-responses) feature from the [`reverse_proxy` directive](reverse_proxy). This may be used with any handler that produces responses, including those from plugins like [FrankenPHP](https://frankenphp.dev/)'s `php_server`.
+
+This directive allows you to [match responses](/docs/caddyfile/response-matchers), and the first matching `handle_response` route or `replace_status` will be invoked. When invoked, the original response body is held back, giving the opportunity to that route to write a different response body, with a new status code or with any necessary response header manipulations. If the route does _not_ write a new response body, then original response body is written instead.
+
+
+## Syntax
+
+```caddy-d
+intercept [<matcher>] {
+	@name {
+		status <code...>
+		header <field> [<value>]
+	}
+
+	replace_status [<matcher>] <code>
+
+	handle_response [<matcher>] {
+		<directives...>
+	}
+}
+```
+
+- **@name** is the name of a [response matcher](/docs/caddyfile/response-matchers). As long as each response matcher has a unique name, multiple matchers can be defined. A response can be matched on the status code and presence or value of a response header.
+
+- **replace_status** <span id="replace_status"/> simply changes the status code of response when matched by the given matcher.
+
+- **handle_response** <span id="handle_response"/> defines the route to execute when matched by the given matcher (or, if a matcher is omitted, all responses). The first matching block will be applied. Inside a `handle_response` block, any other [directives](/docs/caddyfile/directives) can be used.
+
+Within `handle_response` routes, the following placeholders are available to pull information from the original response:
+
+- `{resp.status_code}` The status code of the original response.
+
+- `{resp.header.*}` The headers from the original response.
+
+
+## Examples
+
+When using [FrankenPHP](https://frankenphp.dev/)'s `php_server`, you can use `intercept` to implement `X-Accel-Redirect` support, serving static files as requested by the PHP app:
+
+```caddy
+localhost {
+	root * /srv
+
+	intercept {
+		@accel header X-Accel-Redirect *
+		handle_response @accel {
+			root * /path/to/private/files
+			rewrite {resp.header.X-Accel-Redirect}
+			method GET
+			file_server
+		}
+	}
+
+	php_server
+}
+```

--- a/src/docs/markdown/caddyfile/directives/log.md
+++ b/src/docs/markdown/caddyfile/directives/log.md
@@ -59,7 +59,7 @@ To add custom fields to the log entries, use the [`log_append` directive](log_ap
   - [append](#append)
 - [Examples](#examples)
 
-Since Caddy v2.5, by default, headers with potentially sensitive information (`Cookie`, `Set-Cookie`, `Authorization` and `Proxy-Authorization`) will be logged with empty values. This behaviour can be disabled with the [`log_credentials`](/docs/caddyfile/options#log-credentials) global server option.
+By default, headers with potentially sensitive information (`Cookie`, `Set-Cookie`, `Authorization` and `Proxy-Authorization`) will be logged as `REDACTED` in access logs. This behaviour can be disabled with the [`log_credentials`](/docs/caddyfile/options#log-credentials) global server option.
 
 
 ## Syntax
@@ -67,29 +67,34 @@ Since Caddy v2.5, by default, headers with potentially sensitive information (`C
 ```caddy-d
 log [<logger_name>] {
 	hostnames <hostnames...>
+	no_hostname
 	output <writer_module> ...
 	format <encoder_module> ...
 	level  <level>
 }
 ```
 
-- **logger_name** is an optional override of the logger name for this site.
+- **logger_name** <span id="logger_name"/> is an optional override of the logger name for this site.
 
   By default, a logger name is generated automatically, e.g. `log0`, `log1`, and so on depending on the order of the sites in the Caddyfile. This is only useful if you wish to reliably refer to the output of this logger from another logger defined in global options. See [an example](#multiple-outputs) below.
 
-- **hostnames** is an optional override of the hostnames that this logger applies to.
+- **hostnames** <span id="hostnames"/> is an optional override of the hostnames that this logger applies to.
 
   By default, the logger applies to the hostnames of the site block it appears in, i.e. the site addresses. This is useful if you wish to define different loggers per subdomain in a [wildcard site block](/docs/caddyfile/patterns#wildcard-certificates). See [an example](#wildcard-logs) below.
 
-- **output** configures where to write the logs. See [`output` modules](#output-modules) below.
+- **no_hostname** <span id="no_hostname"/> prevents the logger from being associated with any of the site block's hostnames. By default, the logger is associated with the [site address](/docs/caddyfile/concepts#addresses) that the `log` directive appears in.
+
+  This is useful when you want to log requests to different files based on some condition, such as the request path or method, using the [`log_name` directive](/docs/caddyfile/directives/log_name).
+
+- **output** <span id="output"/> configures where to write the logs. See [`output` modules](#output-modules) below.
 
   Default: `stderr`.
 
-- **format** describes how to encode, or format, the logs. See [`format` modules](#format-modules) below.
+- **format** <span id="format"/> describes how to encode, or format, the logs. See [`format` modules](#format-modules) below.
 
   Default: `console` if `stderr` is detected to be a terminal, `json` otherwise.
 
-- **level** is the minimum entry level to log. Default: `INFO`.
+- **level** <span id="level"/> is the minimum entry level to log. Default: `INFO`.
 
   Note that access logs currently only emit `INFO` and `ERROR` level logs.
 
@@ -251,8 +256,9 @@ format <encoder_module> {
   Default: `seconds`.
   
   May be one of:
-  - `seconds` Floating-point number of seconds elapsed.
-  - `nano` Integer number of nanoseconds elapsed.
+  - `s`, `second` or `seconds` Floating-point number of seconds elapsed.
+  - `ms`, `milli` or `millis` Floating-point number of milliseconds elapsed.
+  - `ns`, `nano` or `nanos` Integer number of nanoseconds elapsed.
   - `string` Using Go's built-in string format, for example `1m32.05s` or `6.31ms`.
 
 - **level_format** The format for levels.

--- a/src/docs/markdown/caddyfile/directives/log_name.md
+++ b/src/docs/markdown/caddyfile/directives/log_name.md
@@ -1,0 +1,49 @@
+---
+title: log_name (Caddyfile directive)
+---
+
+# log_name
+
+Overrides the logger name to use for a request when writing access logs with the [`log` directive](log).
+
+This directive is useful when you want to log requests to different files based on some condition, such as the request path or method.
+
+More than one logger name can be specified, such that the request's log gets pushed to more than one matching logger.
+
+This is often paired with the `log` directive's [`no_hostname`](log#no_hostname) option, which prevents the logger from being associated with any of the site block's hostnames, so that only requests that set `log_name` will push logs to that logger.
+
+
+## Syntax
+
+```caddy-d
+log_name [<matcher>] <names...>
+```
+
+
+## Examples
+
+You may want to log requests to different files, for example you might want to log health checks to a separate file from the main access logs.
+
+Using `no_hostname` in a `log` prevents the logger from being associated with any of the site block's hostnames (i.e. `localhost` here), so that only requests that have `log_name` set to that logger's name will receive logs.
+
+```caddy
+localhost {
+	log {
+		output file ./caddy.access.log
+	}
+
+	log health_check_log {
+		output file ./caddy.access.health.log
+		no_hostname
+	}
+
+	handle /healthz* {
+		log_name health_check_log
+		respond "Healthy"
+	}
+
+	handle {
+		respond "Hello World"
+	}
+}
+```

--- a/src/docs/markdown/caddyfile/directives/uri.md
+++ b/src/docs/markdown/caddyfile/directives/uri.md
@@ -18,23 +18,56 @@ uri [<matcher>] strip_prefix <target>
 uri [<matcher>] strip_suffix <target>
 uri [<matcher>] replace      <target> <replacement> [<limit>]
 uri [<matcher>] path_regexp  <target> <replacement>
+uri [<matcher>] query        [-|+]<param> [<value>]
+uri [<matcher>] query {
+	<param> [<value>] [<replacement>]
+	...
+}
 ```
 
-- The first (non-matcher) argument specifies the operation:
+The first (non-matcher) argument specifies the operation:
 
-	- **strip_prefix** strips the prefix from the path.
+- **strip_prefix** strips the prefix from the path.
 
-	- **strip_suffix** strips the suffix from the path.
+- **strip_suffix** strips the suffix from the path.
 
-	- **replace** performs a substring replacement across the whole URI.
+- **replace** performs a substring replacement across the whole URI.
 
-	- **path_regexp** performs a regular expression replacement on the path portion of the URI.
+	- **&lt;target&gt;** is the prefix, suffix, or search string/regular expression. If a prefix, the leading forward slash may be omitted, since paths always start with a forward slash.
 
-- **&lt;target&gt;** is the prefix, suffix, or search string/regular expression. If a prefix, the leading forward slash may be omitted, since paths always start with a forward slash.
+	- **&lt;replacement&gt;** is the replacement string. Supports using capture groups with `$name` or `${name}` syntax, or with a number for the index, such as `$1`. See the [Go documentation](https://golang.org/pkg/regexp/#Regexp.Expand) for details. If the replacement value is `""`, then the matching text is removed from the value.
 
-- **&lt;replacement&gt;** is the replacement string (only valid with `replace` and `path_regexp`). Supports using capture groups with `$name` or `${name}` syntax, or with a number for the index, such as `$1`. See the [Go documentation](https://golang.org/pkg/regexp/#Regexp.Expand) for details.
+	- **&lt;limit&gt;** is an optional limit to the maximum number of replacements.
 
-- **&lt;limit&gt;** is an optional limit to the maximum number of replacements (only valid with `replace`).
+- **path_regexp** performs a regular expression replacement on the path portion of the URI.
+
+	- **&lt;target&gt;** is the prefix, suffix, or search string/regular expression. If a prefix, the leading forward slash may be omitted, since paths always start with a forward slash.
+
+	- **&lt;replacement&gt;** is the replacement string. Supports using capture groups with `$name` or `${name}` syntax, or with a number for the index, such as `$1`. See the [Go documentation](https://golang.org/pkg/regexp/#Regexp.Expand) for details. If the replacement value is `""`, then the matching text is removed from the value.
+
+- **query** performs manipulations on the URI query, with the mode depending on the prefix to the parameter name or the count of arguments. A block can be used to specify multiple operations at once, grouped and performed in this order: rename 🡒 set 🡒 append 🡒 replace 🡒 delete.
+
+	- With no prefix, the parameter is set with the given value in the query.
+	
+	  For example, `uri query foo bar` will set the value of the `foo` param to `bar`.
+
+	- Prefix with `-` to remove the parameter from the query.
+	
+	  For example, `uri query -foo` will delete the `foo` parameter from the query.
+
+	- Prefix with `+` to append a parameter to the query, with the given value. This will _not_ overwrite an existing parameter with the same name (omit the `+` to overwrite).
+	
+	  For example, `uri query +foo bar` will append `foo=bar` to the query.
+
+	- A param with `>` as an infix will rename the parameter to the value after the `>`. 
+	
+	  For example, `uri query foo>bar` will rename the `foo` parameter to `bar`.
+
+	- With three arguments, query value regular expression replacement is performed, where the first arg is the query param name, the second is the search value, and the third is the replacement. The first arg (param name) may be `*` to perform the replacement on all query params.
+	
+	  Supports using capture groups with `$name` or `${name}` syntax, or with a number for the index, such as `$1`. See the [Go documentation](https://golang.org/pkg/regexp/#Regexp.Expand) for details. If the replacement value is `""`, then the matching text is removed from the value.
+	
+	  For example, `uri query foo ^(ba)r $1z` would replace the value of the `foo` param, where the value began with `bar` resulting in the value becoming `baz`.
 
 URI mutations occur on the normalized or unescaped form of the URI. However, escape sequences can be used in the prefix or suffix patterns to match only those literal escapes at those positions in the request path. For example, `uri strip_prefix /a/b` will rewrite both `/a/b/c` and `/a%2Fb/c` to `/c`; and `uri strip_prefix /a%2Fb` will rewrite `/a%2Fb/c` to `/c`, but won't match `/a/b/c`.
 
@@ -73,4 +106,45 @@ Collapse all repeated slashes in the request path (but not the request query) to
 
 ```caddy-d
 uri path_regexp /{2,} /
+```
+
+Set the value of the `foo` query parameter to `bar`:
+
+```caddy-d
+uri query foo bar
+```
+
+Remove the `foo` parameter from the query:
+
+```caddy-d
+uri query -foo
+```
+
+Rename the `foo` query parameter to `bar`:
+
+```caddy-d
+uri query foo>bar
+```
+
+Append the `bar` parameter to the query:
+
+```caddy-d
+uri query +foo bar
+```
+
+Replace the value of the `foo` query parameter where the value begins with `bar` with `baz`:
+
+```caddy-d
+uri query foo ^(ba)r $1z
+```
+
+Perform multiple query operations at once:
+
+```caddy-d
+uri query {
+	+foo bar
+	-baz
+	qux test
+	renamethis>renamed
+}
 ```

--- a/src/docs/markdown/caddyfile/response-matchers.md
+++ b/src/docs/markdown/caddyfile/response-matchers.md
@@ -1,0 +1,108 @@
+---
+title: Response matchers (Caddyfile)
+---
+
+<script>
+window.$(function() {
+	// Response matchers
+	window.$('pre.chroma .nd:contains("@")')
+		.map(function(k, item) {
+			let text = item.innerText.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+			let url = '#' + item.innerText.replace(/_/g, "-");
+			window.$(item).addClass('nd').removeClass('k')
+			window.$(item).html(`<a href="#syntax" style="color: inherit;">${text}</a>`);
+		});
+	window.$('pre.chroma .k:contains("status")')
+		.html('<a href="#status" style="color: inherit;">status</a>');
+	window.$('pre.chroma .k:contains("header")')
+		.html('<a href="#header" style="color: inherit;">header</a>');
+
+	// We'll add links to all the subdirectives if a matching anchor tag is found on the page.
+	addLinksToSubdirectives();
+});
+</script>
+
+# Response Matchers
+
+**Response matchers** can be used to filter (or classify) responses by specific criteria.
+
+These typically only appear as config inside of certain other directives, to make decisions on the response as it's being written out to the client.
+
+- [Syntax](#syntax)
+- [Matchers](#matchers)
+	- [status](#status)
+	- [header](#header)
+
+## Syntax
+
+```caddy-d
+@name {
+	status <code...>
+	header <field> [<value>]
+}
+```
+
+
+
+## Matchers
+
+### status
+
+```caddy-d
+status <code...>
+```
+
+By HTTP status code.
+
+- **&lt;code...&gt;** is a list of HTTP status codes. Special cases are strings like `2xx` and `3xx`, which match against all status codes in the range of `200`-`299` and `300`-`399`, respectively.
+
+#### Example:
+
+```caddy-d
+@success status 2xx
+```
+
+
+
+### header
+
+```caddy-d
+header <field> [<value>]
+```
+
+By response header fields.
+
+- `<field>` is the name of the HTTP header field to check.
+	- If prefixed with `!`, the field must not exist to match (omit value arg).
+- `<value>` is the value the field must have to match.
+	- If prefixed with `*`, it performs a fast suffix match (appears at the end).
+	- If suffixed with `*`, it performs a fast prefix match (appears at the start).
+	- If enclosed by `*`, it performs a fast substring match (appears anywhere).
+	- Otherwise, it is a fast exact match.
+
+Different header fields within the same set are AND-ed. Multiple values per field are OR'ed.
+
+Note that header fields may be repeated and have different values. Backend applications MUST consider that header field values are arrays, not singular values, and Caddy does not interpret meaning in such quandaries.
+
+#### Example:
+
+Match responses with the `Foo` header containing the value `bar`:
+
+```caddy-d
+@upgrade header Foo *bar*
+```
+
+Match responses with the `Foo` header having the value `bar` OR `baz`:
+
+```caddy-d
+@foo {
+	header Foo bar
+	header Foo baz
+}
+```
+
+Match responses that do not have the `Foo` header field at all:
+
+```caddy-d
+@not_foo header !Foo
+```

--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -319,7 +319,7 @@ Because this command uses the API, the admin endpoint must not be disabled.
 
 `--config` is the config file to apply. If `-`, the config is read from stdin. If not specified, it will try a file called `Caddyfile` in the current working directory and, if it exists, it will adapt it using the `caddyfile` config adapter; otherwise, it is an error if there is no config file to load.
 
-`--adapter` specifies a config adapter to use, if any.
+`--adapter` specifies a config adapter to use, if any. This flag is not necessary if the `--config` filename starts with `Caddyfile` or ends with `.caddyfile` which assumes the `caddyfile` adapter. Otherwise, this flag is required if the provided config file is not in Caddy's native JSON format.
 
 `--address` needs to be used if the admin endpoint is not listening on the default address and if it is different from the address in the provided config file. Note that only TCP addresses are supported at this time.
 
@@ -455,7 +455,7 @@ Runs Caddy and blocks indefinitely; i.e. "daemon" mode.
 
 `--config` specifies an initial config file to immediately load and use. If `-`, the config is read from stdin. If no config is specified, Caddy will run with a blank configuration and use default settings for the [admin API endpoints](/docs/api), which can be used to feed it new configuration. As a special case, if the current working directory has a file called "Caddyfile" and the `caddyfile` config adapter is plugged in (default), then that file will be loaded and used to configure Caddy, even without any command line flags.
 
-`--adapter` is the name of the config adapter to use when loading the initial config, if any. This flag is not necessary if the `--config` filename starts with "Caddyfile" which assumes the `caddyfile` adapter. Otherwise, this flag is required if the provided config file is not in Caddy's native JSON format. Any warnings will be printed to the log, but beware that any adaptation without errors will immediately be used, even if there are warnings. If you want to review the results of the adaptation first, use the [`caddy adapt`](#caddy-adapt) subcommand.
+`--adapter` is the name of the config adapter to use when loading the initial config, if any. This flag is not necessary if the `--config` filename starts with `Caddyfile` or ends with `.caddyfile` which assumes the `caddyfile` adapter. Otherwise, this flag is required if the provided config file is not in Caddy's native JSON format. Any warnings will be printed to the log, but beware that any adaptation without errors will immediately be used, even if there are warnings. If you want to review the results of the adaptation first, use the [`caddy adapt`](#caddy-adapt) subcommand.
 
 `--pidfile` writes the PID to the specified file.
 
@@ -654,7 +654,7 @@ Validates a configuration file, then exits. This command deserializes the config
 
 `--config` is the config file to validate. If `-`, the config is read from stdin. Default is the `Caddyfile` in the current directory, if any.
 
-`--adapter` is the name of the config adapter to use, if the config file is not in Caddy's native JSON format. If the config file starts with `Caddyfile`, the `caddyfile` adapter is used by default.
+`--adapter` is the name of the config adapter to use. This flag is not necessary if the `--config` filename starts with `Caddyfile` or ends with `.caddyfile` which assumes the `caddyfile` adapter. Otherwise, this flag is required if the provided config file is not in Caddy's native JSON format.
 
 `--envfile` loads environment variables from the specified file, in `KEY=VALUE` format. Comments starting with `#` are supported; keys may be prefixed with `export`; values may be double-quoted (double-quotes within can be escaped); multi-line values are supported.
 

--- a/src/docs/markdown/conventions.md
+++ b/src/docs/markdown/conventions.md
@@ -88,7 +88,7 @@ Placeholders are a similar idea to variables in other software. For example, [ng
 </aside>
 
 
-Placeholders are bounded on either side by curly braces `{ }` and contain the variable name inside, for example: `{foo.bar}`. Placeholder braces can be escaped, `\{like so\}`. Variable names are typically namespaced with dots to avoid collisions across modules.
+Placeholders are bounded on either side by curly braces `{ }` and contain the variable name inside, for example: `{foo.bar}`. The opening placeholder brace can be escaped `\{like-this}` to prevent replacement. Variable names are typically namespaced with dots to avoid collisions across modules.
 
 Which placeholders are available depends on the context. Not all placeholders are available in all parts of the config. For example, [the HTTP app sets placeholders](/docs/json/apps/http/#docs) that are only available in areas of the config related to handling HTTP requests.
 
@@ -96,7 +96,8 @@ The following placeholders are always available:
 
 Placeholder | Description
 ------------|-------------
-`{env.*}` | Environment variable (example: `{env.HOME}`)
+`{env.*}` | Environment variable; example: `{env.HOME}`
+`{file.*}` | Contents from a file; example: `{file./path/to/secret.txt}`
 `{system.hostname}` | The system's local hostname
 `{system.slash}` | The system's filepath separator
 `{system.os}` | The system's OS

--- a/src/old/includes/docs/nav.html
+++ b/src/old/includes/docs/nav.html
@@ -29,9 +29,10 @@
 			<a href="/docs/caddyfile">Caddyfile</a>
 			<ul>
 				<li><a href="/docs/caddyfile/concepts">Concepts</a></li>
+				<li><a href="/docs/caddyfile/options">Global options</a></li>
 				<li><a href="/docs/caddyfile/directives">Directives</a></li>
 				<li><a href="/docs/caddyfile/matchers">Request matchers</a></li>
-				<li><a href="/docs/caddyfile/options">Global options</a></li>
+				<li><a href="/docs/caddyfile/response-matchers">Response matchers</a></li>
 				<li><a href="/docs/caddyfile/patterns">Common patterns</a></li>
 			</ul>
 		</li>


### PR DESCRIPTION
This is... very late 🙈 I've been unmotivated to get to this, but I'm finally getting around to completing all this. I was only about halfway done when 2.8.0 first released. This is the second half of the changes in https://github.com/caddyserver/caddy/compare/v2.7.6...v2.8.0

FYI @dunglas @armadi1809 I wouldn't mind a quick look at the bits you guys worked on just in case I missed anything. Wouldn't mind more example ideas if you have any.

Notably @mholt I added a new page for Response Matchers which is now in the left nav, this is extracted from the Reverse Proxy and Encode pages which duplicated this information. Since we were also adding it to Intercept, it was time to split it off on its own page. I also moved Global Options to be above Directives in the nav to match the order they appear in a Caddyfile and in the Concepts page. I think that makes more sense.