### PR TITLE
Fix forward_auth.md example

### DIFF
--- a/src/docs/markdown/caddyfile/directives/forward_auth.md
+++ b/src/docs/markdown/caddyfile/directives/forward_auth.md
@@ -94,11 +94,9 @@ reverse_proxy <upstreams...> {
 	# On a successful response, copy response headers
 	@good status 2xx
 	handle_response @good {
-		request_header {
-			# for example, for each copy_headers field...
-			Remote-User {rp.header.Remote-User}
-			Remote-Email {rp.header.Remote-Email}
-		}
+		# for example, for each copy_headers field...
+		request_header Remote-User {rp.header.Remote-User}
+		request_header Remote-Email {rp.header.Remote-Email}
 	}
 }
 ```


### PR DESCRIPTION
`request_header` doesn't seem to accept multiple headers at a time.