### PR TITLE
tls: Replace usage of deprecated field `trusted_ca_cert_file`

### DIFF
--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -514,7 +514,6 @@ Enable TLS Client Authentication and require clients to present a valid certific
 example.com {
 	tls {
 		client_auth {
-			mode       require_and_verify
 			trust_pool file ../caddy.ca.cer ../root.ca.cer
 		}
 	}

--- a/src/docs/markdown/caddyfile/directives/tls.md
+++ b/src/docs/markdown/caddyfile/directives/tls.md
@@ -508,15 +508,14 @@ https:// {
 }
 ```
 
-Enable TLS Client Authentication and require clients to present a valid certificate that is verified against all the provided CA's via `trusted_ca_cert_file`
+Enable TLS Client Authentication and require clients to present a valid certificate that is verified against all the provided CA's via the [`trust_pool`](#trust_pool) `file` provider:
 
 ```caddy
 example.com {
 	tls {
 		client_auth {
-			mode                 require_and_verify
-			trusted_ca_cert_file ../caddy.ca.cer
-			trusted_ca_cert_file ../root.ca.cer
+			mode       require_and_verify
+			trust_pool file ../caddy.ca.cer ../root.ca.cer
 		}
 	}
 }


### PR DESCRIPTION
I used this example and, after running `caddy validate`, noticed the following warning, so I figured I might as well just submit a PR updating it:

```
WARN    The 'trusted_ca_cert_file' field is deprecated. Use the 'trust_pool' field instead.
```

Additionally, I couldn't find any documentation for the `trusted_ca_cert_file` field, so I'm not sure if this replacement is correct or not.