### PR TITLE
sort submodules lists

### DIFF
--- a/src/old/resources/js/docs-api.js
+++ b/src/old/resources/js/docs-api.js
@@ -342,6 +342,13 @@ function makeSubmoduleList(module, path, value) {
 	}
 	var submodList = '<ul>';
 	if (module.namespaces && module.namespaces[value.module_namespace]) {
+		module.namespaces[value.module_namespace].sort(function(a, b){
+			if(isStandard(a.package) && !isStandard(b.package)) return -1;
+			if(!isStandard(a.package) && isStandard(b.package)) return 1;
+			if(a.name < b.name) return -1;
+			if(a.name > b.name) return 1;
+			return 0;
+		});
 		for (var j = 0; j < module.namespaces[value.module_namespace].length; j++) {
 			var submod = module.namespaces[value.module_namespace][j];
 			var href = canTraverse(module) ? '.'+path+'/'+submod.name+'/' : './'+value.module_namespace+'.'+submod.name;


### PR DESCRIPTION
This has been bothering me for some time and finally bit the bullet to fix it. The submodules were listed without specific order, making looking for a specific module in the list hard. Now they're sorted: standard modules first, then alphabetically.

**Before:**

![image](https://github.com/user-attachments/assets/1ac42d29-51da-4e33-8543-4e88a545fd5f)

**After:**

![image](https://github.com/user-attachments/assets/10cc8f8d-2e6b-4c8a-8dce-0b2cd9b79b61)
