### PR TITLE
Simplify FrankenPHP config snippet

### DIFF
--- a/src/includes/examples/frankenphp.md
+++ b/src/includes/examples/frankenphp.md
@@ -4,7 +4,6 @@
 {
 	# Enable FrankenPHP
 	frankenphp
-	order php_server before file_server
 }
 
 example.com {


### PR DESCRIPTION
The `order` directive isn't necessary anymore.