### PR TITLE
Add metrics per_host documentation to caddy website.

### DIFF
--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -971,7 +971,7 @@ Enables Prometheus metrics collection; necessary before scraping metrics. Note t
 }
 ```
 
-You can add or remove the per_host option to separate metrics for each host rather than for the entire caddy server.
+You can add the `per_host` option to label metrics with the host name of the metric.
 
 ```caddy
 {

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -76,7 +76,9 @@ Possible options are (click on each option to jump to its documentation):
 	}
 	grace_period   <duration>
 	shutdown_delay <duration>
-	metrics
+	metrics {
+        per_host
+    }
 
 	# TLS Options
 	auto_https off|disable_redirects|ignore_loaded_certs|disable_certs

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -969,6 +969,15 @@ Enables Prometheus metrics collection; necessary before scraping metrics. Note t
 }
 ```
 
+You can add or remove the per_host option to separate metrics for each host rather than for the entire caddy server.
+
+```caddy
+{
+	metrics {
+        per_host
+    }
+}
+```
 
 ##### `trace`
 

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -77,8 +77,8 @@ Possible options are (click on each option to jump to its documentation):
 	grace_period   <duration>
 	shutdown_delay <duration>
 	metrics {
-        per_host
-    }
+		per_host
+	}
 
 	# TLS Options
 	auto_https off|disable_redirects|ignore_loaded_certs|disable_certs

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -976,8 +976,8 @@ You can add the `per_host` option to label metrics with the host name of the met
 ```caddy
 {
 	metrics {
-        per_host
-    }
+		per_host
+	}
 }
 ```
 

--- a/src/docs/markdown/metrics.md
+++ b/src/docs/markdown/metrics.md
@@ -23,7 +23,7 @@ If using a Caddyfile, enable metrics [in global options](/docs/caddyfile/options
 
 If using JSON, add `"metrics": {}` to your [`apps > http > servers` configuration](/docs/json/apps/http/servers/).
 
-To add per host metrics you can insert the per_host option. Host specific metrics will now have a Host tag.
+To add per-host metrics you can insert the `per_host` option. Host specific metrics will now have a Host tag.
 
 ```caddy
 {

--- a/src/docs/markdown/metrics.md
+++ b/src/docs/markdown/metrics.md
@@ -17,9 +17,7 @@ If using a Caddyfile, enable metrics [in global options](/docs/caddyfile/options
 
 ```caddy
 {
-    servers {
-        metrics
-    }
+	metrics
 }
 ```
 
@@ -29,11 +27,9 @@ To add per host metrics you can insert the per_host option. Host specific metric
 
 ```caddy
 {
-    servers {
-        metrics {
-            per_host
-        }
-    }
+	metrics {
+		per_host
+	}
 }
 ```
 

--- a/src/docs/markdown/metrics.md
+++ b/src/docs/markdown/metrics.md
@@ -25,6 +25,18 @@ If using a Caddyfile, enable metrics [in global options](/docs/caddyfile/options
 
 If using JSON, add `"metrics": {}` to your [`apps > http > servers` configuration](/docs/json/apps/http/servers/).
 
+To add per host metrics you can insert the per_host option. Host specific metrics will now have a Host tag.
+
+```caddy
+{
+    servers {
+        metrics {
+            per_host
+        }
+    }
+}
+```
+
 ## Prometheus
 
 [Prometheus](https://prometheus.io) is a monitoring platform that collects


### PR DESCRIPTION
I saw that per_host was an option that I didn't see in docs. I thought it'd be useful to add this so others don't have a hard time discovering it exists.