### PR TITLE
Prevent Horizontal Overflow on Homepage when using a Phone

### DIFF
--- a/src/resources/css/marketing.css
+++ b/src/resources/css/marketing.css
@@ -247,7 +247,7 @@ section.dark .cols {
 
 
 .cols .col {
-	min-width: 350px;
+	min-width: 300px;
 	padding-left: 1em;
 	flex: 1;
 }


### PR DESCRIPTION
This fixes a Horizontal Overflow that appears on Mobile. Here is an Example of that
![Screenshot_20250329-130012](https://github.com/user-attachments/assets/36f64c26-1284-4f08-bfe4-8de59fe4ba17)

