### PR TITLE
reverse_proxy: remove reference to deprecated `tls_trusted_ca_certs`

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -771,13 +771,13 @@ example.com {
 ```
 
 
-Instead you may establish trust with the upstream by explicitly [trusting the upstream's certificate](#tls_trusted_ca_certs), and (optionally) setting TLS-SNI to match the hostname in the upstream's certificate:
+Instead you may establish trust with the upstream by explicitly [trusting the upstream's certificate](#tls_trust_pool), and (optionally) setting TLS-SNI to match the hostname in the upstream's certificate:
 
 ```caddy
 example.com {
 	reverse_proxy 10.0.0.1:443 {
 		transport http {
-			tls_trusted_ca_certs /path/to/cert.pem
+			tls_trust_pool file /path/to/cert.pem
 			tls_server_name app.example.com
 		}
 	}


### PR DESCRIPTION
closes #465