### PR TITLE
Strip headers when proxying errors to external service

### DIFF
--- a/src/docs/markdown/caddyfile/directives/handle_errors.md
+++ b/src/docs/markdown/caddyfile/directives/handle_errors.md
@@ -83,6 +83,7 @@ Reverse proxy to a professional server that is highly qualified for handling HTT
 handle_errors {
 	rewrite * /{err.status_code}
 	reverse_proxy https://http.cat {
+		header_up -*
 		header_up Host {upstream_hostport}
 		replace_status {err.status_code}
 	}


### PR DESCRIPTION
I think this example error handling system from the docs might send potentially sensitive headers to an untrusted third party. This is my attempt to recommend stripping those headers in the request to http.cat. Thank you!