### PR TITLE
Add documentation for the `set` option in `request_body` directive

### DIFF
--- a/src/docs/markdown/caddyfile/directives/request_body.md
+++ b/src/docs/markdown/caddyfile/directives/request_body.md
@@ -17,7 +17,7 @@ request_body [<matcher>] {
 
 - **max_size** is the maximum size in bytes allowed for the request body. It accepts all size values supported by [go-humanize](https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants). Reads of more bytes will return an error with HTTP status `413`.
 
-⚠️ <i>Experimental</i> <span style='white-space: pre;'> | </span> <span>v2.10.x+</span>
+⚠️ <i>Experimental</i> <span style='white-space: pre;'> | </span> <span>v2.10.0+</span>
 - **set** allows setting the request body to specific content. The content can include placeholders to dynamically insert data.
 
 ## Examples
@@ -39,7 +39,7 @@ Set the request body with a JSON structure containing a SQL query:
 example.com {
 	handle /jazz {
 		request_body {
-			set `\{"statementText":"SELECT name, genre, debut_year FROM artists WHERE genre = 'Jazz'"\}`
+			set `\{"statementText":"SELECT name, genre, debut_year FROM artists WHERE genre = 'Jazz'"}`
 		}
 
 		reverse_proxy localhost:8080 {
@@ -47,6 +47,6 @@ example.com {
 			method POST
 			rewrite * /execute-sql
 		}
-    }
+	}
 }
 ```

--- a/src/docs/markdown/caddyfile/directives/request_body.md
+++ b/src/docs/markdown/caddyfile/directives/request_body.md
@@ -6,17 +6,19 @@ title: request_body (Caddyfile directive)
 
 Manipulates or sets restrictions on the bodies of incoming requests.
 
-
 ## Syntax
 
 ```caddy-d
 request_body [<matcher>] {
 	max_size <value>
+	set <body_content>
 }
 ```
 
 - **max_size** is the maximum size in bytes allowed for the request body. It accepts all size values supported by [go-humanize](https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants). Reads of more bytes will return an error with HTTP status `413`.
 
+⚠️ <i>Experimental</i> <span style='white-space: pre;'> | </span> <span>v2.10.x+</span>
+- **set** allows setting the request body to specific content. The content can include placeholders to dynamically insert data.
 
 ## Examples
 
@@ -28,5 +30,23 @@ example.com {
 		max_size 10MB
 	}
 	reverse_proxy localhost:8080
+}
+```
+
+Set the request body with a JSON structure containing a SQL query:
+
+```caddy
+example.com {
+	handle /jazz {
+		request_body {
+			set `\{"statementText":"SELECT name, genre, debut_year FROM artists WHERE genre = 'Jazz'"\}`
+		}
+
+		reverse_proxy localhost:8080 {
+			header_up Content-Type application/json
+			method POST
+			rewrite * /execute-sql
+		}
+    }
 }
 ```


### PR DESCRIPTION
With Caddy v2.10.0, the `set` option was introduced to the `request_body` directive (see [caddyserver/caddy#5795](https://github.com/caddyserver/caddy/pull/5795)).

This PR updates the documentation to include details about the `set` option, explaining its functionality and providing an example of its usage.