### PR TITLE
Add .internal to list of TLDs that will not qualify for public cert

### DIFF
--- a/src/docs/markdown/automatic-https.md
+++ b/src/docs/markdown/automatic-https.md
@@ -117,7 +117,7 @@ All hostnames (domain names) qualify for fully-managed certificates if they:
 
 In addition, hostnames qualify for publicly-trusted certificates if they:
 
-- are not localhost (including `.localhost`, `.local` and `.home.arpa` TLDs)
+- are not localhost (including `.localhost`, `.local`, `.internal` and `.home.arpa` TLDs)
 - are not an IP address
 - have only a single wildcard `*` as the left-most label
 


### PR DESCRIPTION
Makes the documentation a little clearer, that sites with .internal TLDs will not automatically get publicly trusted certificates.

Corroborates with https://github.com/caddyserver/certmagic/blob/master/certificates.go#L574