### PR TITLE
Update install docs for newer releases of RHEL and derivatives

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -83,7 +83,7 @@ If you wish to use the packaged support files (systemd services, bash completion
 
 This package comes with both of Caddy's [systemd service](/docs/running#linux-service) unit files, but does not enable them by default. Using the service is recommended. If you do, please read the [service usage instructions](/docs/running#using-the-service).
 
-Fedora or RHEL/CentOS 8:
+Fedora or RHEL/CentOS 8 and later:
 
 <pre><code class="cmd"><span class="bash">dnf install 'dnf-command(copr)'</span>
 <span class="bash">dnf copr enable @caddy/caddy</span>


### PR DESCRIPTION
The existing installation instructions for Fedora and RHEL/CentOS 8 also apply to newer versions of RHEL and its derivatives, including versions 9 and 10. This PR updates the page to clarify that compatibility.