### PR TITLE
docs: Add `.test` as an internal-only hostname

### DIFF
--- a/src/docs/markdown/automatic-https.md
+++ b/src/docs/markdown/automatic-https.md
@@ -117,7 +117,7 @@ All hostnames (domain names) qualify for fully-managed certificates if they:
 
 In addition, hostnames qualify for publicly-trusted certificates if they:
 
-- are not localhost (including `.localhost`, `.local`, `.internal` and `.home.arpa` TLDs)
+- are not localhost (including `.localhost`, `.local`, `.internal`, `.test` and `.home.arpa` TLDs)
 - are not an IP address
 - have only a single wildcard `*` as the left-most label
 


### PR DESCRIPTION
## ⚠️ This is PR depends on a change in "certmagic"
**Do not merge this PR until the related PR below has been merged & released.** This change will only make sense if this change in `certmagic` is made available:

- https://github.com/caddyserver/certmagic/pull/351

## What this PR does
- Adds `.test` as an "internal-only host name"

## More information on this change
See the `certmagic` PR above for more information explaining this proposed change.