### PR TITLE
add version notice for excluded hidden files for import

### DIFF
--- a/src/docs/markdown/caddyfile/directives/import.md
+++ b/src/docs/markdown/caddyfile/directives/import.md
@@ -42,7 +42,7 @@ import <pattern> [<args...>] [{block}]
 
 ## Examples
 
-Import all files in an adjacent sites-enabled folder (except hidden files):
+Import all files in an adjacent sites-enabled folder. Starting with v2.6.3 (so any recent release), hidden files are automatically excluded. If you are using an older version, be aware of hidden lock files some editors create.:
 
 ```caddy-d
 import sites-enabled/*


### PR DESCRIPTION
This PR intents to warn users that use an older version of caddy, like on debian where the version is currently on 2.6.2, that they must be careful with hidden files (i.e. from editors).