### PR TITLE
Remove dud restriction for `caddy reload`

### DIFF
--- a/src/docs/markdown/command-line.md
+++ b/src/docs/markdown/command-line.md
@@ -321,7 +321,7 @@ Because this command uses the API, the admin endpoint must not be disabled.
 
 `--adapter` specifies a config adapter to use, if any. This flag is not necessary if the `--config` filename starts with `Caddyfile` or ends with `.caddyfile` which assumes the `caddyfile` adapter. Otherwise, this flag is required if the provided config file is not in Caddy's native JSON format.
 
-`--address` needs to be used if the admin endpoint is not listening on the default address and if it is different from the address in the provided config file. Note that only TCP addresses are supported at this time.
+`--address` needs to be used if the admin endpoint is not listening on the default address and if it is different from the address in the provided config file.
 
 `--force` will cause a reload to happen even if the specified config is the same as what Caddy is already running. Can be useful to force Caddy to reprovision its modules, which can have side-effects, for example: reloading manually-loaded TLS certificates.
 


### PR DESCRIPTION
I've given it a quick test and you can specify `caddy reload --address unix//run/api.socket` or similar without issue.