### PR TITLE
Proposal: Update Ansible community role

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -181,11 +181,19 @@ You may need to adjust the Windows firewall rules to allow non-localhost incomin
 
 ## Ansible
 
-_Note: This is a community-maintained installation method._
+_Note: These are community-maintained installation methods._
+
+xcaddy - Build Caddy with plugins:
 
 <pre><code class="cmd bash">ansible-galaxy role install sebdanielsson.xcaddy</code></pre>
 
 [**View the Ansible role repository**](https://github.com/sebdanielsson/ansible-role-xcaddy)
+
+caddy - Install Caddy from the distro repository:
+
+<pre><code class="cmd bash">ansible-galaxy install nvjacobo.caddy</code></pre>
+
+[**View the Ansible role repository**](https://github.com/nvjacobo/caddy)
 
 
 

--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -183,9 +183,9 @@ You may need to adjust the Windows firewall rules to allow non-localhost incomin
 
 _Note: This is a community-maintained installation method._
 
-<pre><code class="cmd bash">ansible-galaxy install nvjacobo.caddy</code></pre>
+<pre><code class="cmd bash">ansible-galaxy role install sebdanielsson.xcaddy</code></pre>
 
-[**View the Ansible role repository**](https://github.com/nvjacobo/caddy)
+[**View the Ansible role repository**](https://github.com/sebdanielsson/ansible-role-xcaddy)
 
 
 


### PR DESCRIPTION
Updates the community Ansible role for installing Caddy.

What the new role offers:

-  Build Caddy with plugins using xcaddy.
-  Build Caddy for almost any distro for amd64 and arm64 systems (Tests for Debian-based, Fedora-based, Arch-based).
-  Customize values like GOPROXY (Useful for enterprises that might want to use their own Go proxy).