### PR TITLE
Fix mixup in route docs

### DIFF
--- a/src/docs/markdown/caddyfile/directives/route.md
+++ b/src/docs/markdown/caddyfile/directives/route.md
@@ -33,7 +33,7 @@ While the [built-in order](/docs/caddyfile/directives#directive-order) is compat
 
 To illustrate, consider the case of two terminating handlers: [`redir`](redir) and [`file_server`](file_server). Both write the response to the client and do not call the next handler in the chain, so only one of these will be executed for a certain request. So which comes first? Normally, `redir` is executed before `file_server` because usually you would want to issue a redirect only in specific cases and serve files in the general case.
 
-However, there may be occasions where the second directive (`redir`) has a more specific matcher than the second (`file_server`). In other words, you want to redirect in the general case, and serve only a specific file.
+However, there may be occasions where the first directive (`file_server`) has a more specific matcher than the second (`redir`). In other words, you want to redirect in the general case, and serve only a specific file.
 
 So you might try a Caddyfile like this (but this will not work as expected!):
 


### PR DESCRIPTION
The word "second" was used twice, and the directives visible in the sample below were swapped.
I feel that even with my fix the section is still a bit confusing, since the paragraph above describes a different order. Since the line order doesn't make a difference in the first place, one could also omit the "first" and "second" and just write this instead:

> However, there may be occasions where the `file_server` has a more specific matcher than `redir`. In other words, you want to redirect in the general case, and serve only a specific file.