### PR TITLE
Fix assumptions when PROXY protocol is used

### DIFF
--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -203,7 +203,7 @@ expression client_ip('<ranges...>')
 
 By the client IP address. Accepts exact IPs or CIDR ranges. IPv6 zones are supported.
 
-This matcher is best used when the [`trusted_proxies`](/docs/caddyfile/options#trusted-proxies) global option is configured, otherwise it acts identically to the [`remote_ip`](#remote-ip) matcher. Only requests from trusted proxies will have their client IP parsed at the start of the request; untrusted requests will use the remote IP address of the immediate peer.
+This matcher is best used when the [`trusted_proxies`](/docs/caddyfile/options#trusted-proxies) global option is configured, otherwise it acts identically to the [`remote_ip`](#remote-ip) matcher. Only requests from trusted proxies will have their client IP parsed at the start of the request; untrusted requests will use the remote IP address of the immediate peer or the address set via [PROXY protocol](/docs/caddyfile/options#proxy-protocol).
 
 As a shortcut, `private_ranges` can be used to match all private IPv4 and IPv6 ranges. It's the same as specifying all of these ranges: `192.168.0.0/16 172.16.0.0/12 10.0.0.0/8 127.0.0.1/8 fd00::/8 ::1`
 
@@ -821,7 +821,7 @@ remote_ip <ranges...>
 expression remote_ip('<ranges...>')
 ```
 
-By remote IP address (i.e. the IP address of the immediate peer). Accepts exact IPs or CIDR ranges. IPv6 zones are supported.
+By remote IP address (i.e. the IP address of the immediate peer or the address set via [PROXY protocol](/docs/caddyfile/options#proxy-protocol)). Accepts exact IPs or CIDR ranges. IPv6 zones are supported.
 
 As a shortcut, `private_ranges` can be used to match all private IPv4 and IPv6 ranges. It's the same as specifying all of these ranges: `192.168.0.0/16 172.16.0.0/12 10.0.0.0/8 127.0.0.1/8 fd00::/8 ::1`
 

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -859,6 +859,8 @@ The [`http_redirect`](/docs/json/apps/http/servers/listener_wrappers/http_redire
 
 The [`proxy_protocol`](/docs/json/apps/http/servers/listener_wrappers/proxy_protocol/) listener wrapper (prior to v2.7.0 it was only available via a plugin) enables [PROXY protocol](https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt) parsing (popularized by HAProxy). This must be used _before_ the `tls` listener wrapper since it parses plaintext data at the start of the connection:
 
+Be aware that metadata from the PROXY protocol may be applied to the connection before the evaluation of mathers or [`trusted_proxies`](/docs/caddyfile/options#trusted-proxies). The IP address of the immediate peer will be lost for further evaluation.
+
 ```caddy-d
 proxy_protocol {
 	timeout <duration>
@@ -943,7 +945,7 @@ The interval at which TCP keepalive packets are sent to keep the connection aliv
 
 Allows configuring IP ranges (CIDRs) of proxy servers from which requests should be trusted. By default, no proxies are trusted.
 
-Enabling this causes trusted requests to have the _real_ client IP parsed from HTTP headers (by default, `X-Forwarded-For`; see [`client_ip_headers`](#client-ip-headers) to configure other headers). If trusted, the client IP is added to [access logs](/docs/caddyfile/directives/log), is available as a `{client_ip}` [placeholder](/docs/caddyfile/concepts#placeholders), and allows the use of the [`client_ip` matcher](/docs/caddyfile/matchers#client-ip). If the request is not from a trusted proxy, then the client IP is set to the remote IP address of the direct incoming connection. By default, the IPs in headers are parsed left-to-right. See [`trusted_proxies_strict`](#trusted-proxies-strict) to alter this behaviour.
+Enabling this causes trusted requests to have the _real_ client IP parsed from HTTP headers (by default, `X-Forwarded-For`; see [`client_ip_headers`](#client-ip-headers) to configure other headers). If trusted, the client IP is added to [access logs](/docs/caddyfile/directives/log), is available as a `{client_ip}` [placeholder](/docs/caddyfile/concepts#placeholders), and allows the use of the [`client_ip` matcher](/docs/caddyfile/matchers#client-ip). If the request is not from a trusted proxy, then the client IP is set to the remote IP address of the direct incoming connection or to the address set by [PROXY protocol](/docs/caddyfile/options#proxy-protocol) if used. By default, the IPs in headers are parsed left-to-right. See [`trusted_proxies_strict`](#trusted-proxies-strict) to alter this behaviour.
 
 Some matchers or handlers may use the trust status of the request to make decisions. For example, if trusted, the [`reverse_proxy`](/docs/caddyfile/directives/reverse_proxy#defaults) handler will proxy and augment the sensitive `X-Forwarded-*` request headers.
 


### PR DESCRIPTION
The PROXY protocol listener_wrapper was added to Caddy later on and it seems like the documentation makes assumptions about certain things which are no longer true when the PROXY protocol is being used.

For example, sometimes the documentation talks about the immediate peer. When using the PROXY protocol, however, this becomes the IP from the PROXY protocol metadata instead.

This patch tries to fix the documentation by adding short hints about the behavior at the `client_ip`, `remote_ip`, `trusted_proxies´ and the `proxy_protocol` settings.