### PR TITLE
Fix accessibility violations: Add alt text to citation images

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -397,7 +397,7 @@
 					</p>
 					<div class="cols experts">
 						<div class="col">
-							<a href="https://doi.org/10.1145/3319535.3363192"><img src="/resources/images/cites/aas.png" class="cite"></a>
+							<a href="https://doi.org/10.1145/3319535.3363192"><img src="/resources/images/cites/aas.png" class="cite" alt="Let's Encrypt: An Automated Certificate Authority to Encrypt the Entire Web"></a>
 							<p>
 								"Servers running Caddy exhibit nearly ubiquitous HTTPS deployment and use modern TLS configurations. ... We hope to see other popular server software follow Caddy's lead."
 							</p>
@@ -406,7 +406,7 @@
 							</p>
 						</div>
 						<div class="col">
-							<a href="https://www.usenix.org/conference/usenixsecurity17/technical-sessions/presentation/krombholz"><img src="/resources/images/cites/krombholz.png" class="cite"></a>
+							<a href="https://www.usenix.org/conference/usenixsecurity17/technical-sessions/presentation/krombholz"><img src="/resources/images/cites/krombholz.png" class="cite" alt="&quot;I Have No Idea What I'm Doing&quot; - On the Usability of Deploying HTTPS"></a>
 							<p>
 								"TLS must be enabled by default ... and the Caddy web server is a good and usable example."
 							</p>
@@ -415,7 +415,7 @@
 							</p>
 						</div>
 						<div class="col">
-							<a href="https://doi.org/10.1145/2987443.2987480"><img src="/resources/images/cites/springall.png" class="cite"></a>
+							<a href="https://doi.org/10.1145/2987443.2987480"><img src="/resources/images/cites/springall.png" class="cite" alt="Measuring the Security Harm of TLS Crypto Shortcuts"></a>
 							<p>
 								"No popular server software does [session ticket key rotation], with the exception of Caddy."
 							</p>


### PR DESCRIPTION
## Summary
This PR resolves 3 accessibility violations by adding descriptive alt text to citation images in the experts section.

## Problem
<img width="2560" height="918" alt="image" src="https://github.com/user-attachments/assets/50d48184-86f8-441a-8efd-53136a5856a2" />

The IBM Equal Access Accessibility Checker identified that three `<img>` elements were missing alternative text, violating WCAG Level A guidelines. These images are academic paper citations that link to research publications but were not accessible to screen reader users.
- Violation: Hyperlinks must have an accessible name for their purpose
- Impact: Users relying on assistive technologies could not understand the purpose of these linked citation images.

## Solution
Added descriptive `alt` attributes to all three citation images:

- Let's Encrypt paper (aas.png): Alt text describes the paper title and topic
- HTTPS Usability paper (krombholz.png): Alt text includes the quoted paper title
- TLS Crypto Shortcuts paper (springall.png): Alt text provides the paper title

## Changes

- Added meaningful alt text to 3 `<img>` elements in `src/index.html`
- Alt text reflects the academic paper titles/topics being cited
- Maintains semantic HTML structure without breaking existing layout

## Testing
✅ All 3 accessibility violations resolved
✅ Images remain properly linked to DOI/conference URLs
✅ Screen readers can now announce meaningful context for each citation
✅ Visual presentation unchanged