### PR TITLE
Language clarification/typo

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -514,7 +514,7 @@ These are examples of valid addresses:
 | `:443`               | HTTPS catch-all due to matching the [`https_port`](/docs/caddyfile/options#http-port) default |
 | `:8080`              | HTTP on non-standard port, no `Host` matcher |
 | `localhost:8080`     | HTTPS on non-standard port, due to having a valid domain |
-| `https://example.com:443` | HTTPS, but both `https://` and `:443` are redundant |
+| `https://example.com:443` | HTTPS, but having both `https://` and `:443` is redundant |
 | `127.0.0.1` | HTTPS, with a locally-trusted IP certificate |
 | `http://127.0.0.1` | HTTP, with an IP address `Host` matcher (rejects `localhost`) |
 

--- a/src/docs/markdown/caddyfile/options.md
+++ b/src/docs/markdown/caddyfile/options.md
@@ -866,7 +866,7 @@ The [`http_redirect`](/docs/json/apps/http/servers/listener_wrappers/http_redire
 
 The [`proxy_protocol`](/docs/json/apps/http/servers/listener_wrappers/proxy_protocol/) listener wrapper (prior to v2.7.0 it was only available via a plugin) enables [PROXY protocol](https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt) parsing (popularized by HAProxy). This must be used _before_ the `tls` listener wrapper since it parses plaintext data at the start of the connection:
 
-Be aware that metadata from the PROXY protocol may be applied to the connection before the evaluation of mathers or [`trusted_proxies`](/docs/caddyfile/options#trusted-proxies). The IP address of the immediate peer will be lost for further evaluation.
+Be aware that metadata from the PROXY protocol may be applied to the connection before the evaluation of matchers or [`trusted_proxies`](/docs/caddyfile/options#trusted-proxies). The IP address of the immediate peer will be lost for further evaluation.
 
 ```caddy-d
 proxy_protocol {


### PR DESCRIPTION
* Fixed typo "mather"
* For me, "both X and Y are redundant" means that you can **delete both** and it still works. Changed that to "having both X and Y is redundant", i.e., one is enough. (I am not a native speaker, though.)