### PR TITLE
Use hostport instead of host to recover Host header overriden

### DIFF
--- a/src/docs/markdown/caddyfile/directives/reverse_proxy.md
+++ b/src/docs/markdown/caddyfile/directives/reverse_proxy.md
@@ -522,7 +522,7 @@ Since Caddy v2.11.0, this is done automatically, so it is no longer necessary to
 
 ```caddy-d
 reverse_proxy https://example.com {
-	header_up Host {host}
+	header_up Host {hostport}
 }
 ```
 


### PR DESCRIPTION
Fix caddyserver/caddy#7527

After v2.11.0, caddy sets Host to `{upstream_hostport}` automatically if TLS, and per [document](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#https), to opt out of this behavior, set the Host header to its original value by:

```
reverse_proxy https://example.com {
	header_up Host {host}
}
```

however, `{host}` only includes the host part of `Host` header, if the `Host` consists of a port, this cause inconsistence between original request and reverse proxied request. It would be problematic in some use cases like reverse proxy for S3 service as `Host` is included in signature calclution.