### PR TITLE
docs: add sudo prefix to chmod commands in Debian/Ubuntu install instructions

### DIFF
--- a/src/docs/markdown/install.md
+++ b/src/docs/markdown/install.md
@@ -64,8 +64,8 @@ After installing, please read the [service usage instructions](/docs/running#usi
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list</span>
-<span class="bash">chmod o+r /usr/share/keyrings/caddy-stable-archive-keyring.gpg</span>
-<span class="bash">chmod o+r /etc/apt/sources.list.d/caddy-stable.list</span>
+<span class="bash">sudo chmod o+r /usr/share/keyrings/caddy-stable-archive-keyring.gpg</span>
+<span class="bash">sudo chmod o+r /etc/apt/sources.list.d/caddy-stable.list</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 
@@ -74,8 +74,8 @@ After installing, please read the [service usage instructions](/docs/running#usi
 <pre><code class="cmd"><span class="bash">sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-testing-archive-keyring.gpg</span>
 <span class="bash">curl -1sLf 'https://dl.cloudsmith.io/public/caddy/testing/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-testing.list</span>
-<span class="bash">chmod o+r /usr/share/keyrings/caddy-testing-archive-keyring.gpg</span>
-<span class="bash">chmod o+r /etc/apt/sources.list.d/caddy-testing.list</span>
+<span class="bash">sudo chmod o+r /usr/share/keyrings/caddy-testing-archive-keyring.gpg</span>
+<span class="bash">sudo chmod o+r /etc/apt/sources.list.d/caddy-testing.list</span>
 <span class="bash">sudo apt update</span>
 <span class="bash">sudo apt install caddy</span></code></pre>
 


### PR DESCRIPTION
The chmod commands modify files in /usr/share/keyrings/ and /etc/apt/sources.list.d/ which require root permissions.

Related: #523 (closed) - chmod commands are needed, but they need sudo prefix.