### PR TITLE
Fix nav.html include path in index.html

### DIFF
--- a/src/docs/json/index.html
+++ b/src/docs/json/index.html
@@ -12,7 +12,7 @@
 	<body>
 		{{include "/includes/header.html" ""}}
 		<main>
-			{{include "/includes/docs/nav.html"}}
+			{{include "/old/includes/docs/nav.html"}}
 			<div class="article-container">
 				<div class="paper" id="paper1"></div>
 				<div class="paper" id="paper2"></div>


### PR DESCRIPTION
Fix a broken include path in `src/docs/json/index.html` by changing `{{include "/includes/docs/nav.html"}}` to `{{include "/old/includes/docs/nav.html"}}`, so the JSON docs page loads the correct nav partial.