### PR TITLE
docs: clarify header matcher values

### DIFF
--- a/src/docs/markdown/caddyfile/matchers.md
+++ b/src/docs/markdown/caddyfile/matchers.md
@@ -399,7 +399,7 @@ Some more examples using [CEL expressions](#expression). Keep in mind that place
 ### header
 
 ```caddy-d
-header <field> [<value> ...]
+header <field> [<value>]
 
 expression header({'<field>': '<value>'})
 ```
@@ -408,13 +408,13 @@ By request header fields.
 
 - `<field>` is the name of the HTTP header field to check.
 	- If prefixed with `!`, the field must not exist to match (omit value arg).
-- `<value>` is the value the field must have to match. One or more may be specified.
+- `<value>` is the value the field must have to match.
 	- If prefixed with `*`, it performs a fast suffix match (appears at the end).
 	- If suffixed with `*`, it performs a fast prefix match (appears at the start).
 	- If enclosed by `*`, it performs a fast substring match (appears anywhere).
 	- Otherwise, it is a fast exact match.
 
-Different header fields within the same set are AND-ed. Multiple values per field are OR'ed.
+Different header fields within the same set are AND-ed. To match multiple values for the same field, specify one `header` matcher per value within the same matcher set; those values are OR'ed.
 
 Note that header fields may be repeated and have different values. Backend applications MUST consider that header field values are arrays, not singular values, and Caddy does not interpret meaning in such quandaries.
 


### PR DESCRIPTION
## Summary

- Clarify that the Caddyfile `header` matcher accepts one value per matcher line
- Explain that multiple values for the same field should be written as repeated `header` matchers in the same matcher set
- Keep the existing `Foo bar` / `Foo baz` example aligned with the syntax text

Fixes #503.

## Verification

- `git diff --check`
- `printf ':2015 {\n\t@foo {\n\t\theader Foo bar\n\t\theader Foo baz\n\t}\n\trespond @foo "matched"\n}\n' | docker run --rm -i caddy:2 caddy adapt --config /dev/stdin --adapter caddyfile`
- `printf ':2015 {\n\t@foo {\n\t\theader Foo bar baz\n\t}\n\trespond @foo "matched"\n}\n' | docker run --rm -i caddy:2 caddy adapt --config /dev/stdin --adapter caddyfile` fails with `malformed header matcher`, confirming the confusing single-line form is not accepted.
- `docker run --rm --name caddy-website -p 8443:443 -v "$PWD:/wd" caddy:2 sh -c 'cd /wd && caddy run'`, then `curl -ks 'https://localhost:8443/docs/caddyfile/matchers#header'` to confirm the updated paragraph renders in the generated docs HTML.
