### PR TITLE
docs: mention file placeholder for secrets

### DIFF
--- a/src/docs/markdown/caddyfile/concepts.md
+++ b/src/docs/markdown/caddyfile/concepts.md
@@ -821,4 +821,16 @@ For example, if you have the [`caddy-dns/cloudflare` plugin <img src="/old/resou
 }
 ```
 
+Environment variables are convenient, but sensitive values in a process environment can be exposed by process inspection, child process inheritance, logs, crash dumps, or platform diagnostics.
+
+For secrets, prefer your platform's secret management mechanism when available. If the secret is provided as a file, you can use the [global `{file.*}` placeholder](/docs/conventions#placeholders) in config fields which support placeholders:
+
+```caddy
+{
+	acme_dns cloudflare {file./run/secrets/cloudflare_api_token}
+}
+```
+
+This does not make the secret inaccessible to Caddy; the Caddy process still needs permission to read the file. It avoids placing the secret value in the process-wide environment.
+
 If you're running Caddy as a systemd service, see [these instructions](/docs/running#overrides) for setting service overrides to define your environment variables.

--- a/src/docs/markdown/conventions.md
+++ b/src/docs/markdown/conventions.md
@@ -97,7 +97,7 @@ The following placeholders are always available (global):
 Placeholder | Description
 ------------|-------------
 `{env.*}` | Environment variable; example: `{env.HOME}`
-`{file.*}` | Contents from a file; example: `{file./path/to/secret.txt}`
+`{file.*}` | Contents from a file, useful when a secret is supplied as a file; example: `{file./path/to/secret.txt}`
 `{system.hostname}` | The system's local hostname
 `{system.slash}` | The system's filepath separator
 `{system.os}` | The system's OS


### PR DESCRIPTION
## Summary

- Add a security note to the Caddyfile environment variables section explaining that process environment secrets can be exposed through runtime and diagnostic surfaces
- Show `{file.*}` as an alternative when a secret is supplied as a file and the config field supports placeholders
- Expand the global placeholder table to make `{file.*}` easier to discover for file-supplied secrets

Fixes #507.

## Security note

This does not claim that file-based secrets are inaccessible to Caddy. The Caddy process still needs permission to read the file. The docs only clarify that `{file.*}` avoids placing the secret value in the process-wide environment.

## Verification

- `git diff --check`
- `docker run --rm --name caddy-website-507 -p 8443:443 -v "$PWD:/wd" caddy:2 sh -c 'cd /wd && caddy run'`
- `curl -ks 'https://localhost:8443/docs/caddyfile/concepts#environment-variables' | rg 'process environment|file\.\*|process-wide environment|cloudflare_api_token'`
- `curl -ks 'https://localhost:8443/docs/conventions#placeholders' | rg 'file\.\*|secret is supplied as a file'`
